### PR TITLE
fix: update stale sim.drivers.comsol.lib paths in skill docs

### DIFF
--- a/src/sim_plugin_comsol/_skills/comsol/SKILL.md
+++ b/src/sim_plugin_comsol/_skills/comsol/SKILL.md
@@ -120,7 +120,7 @@ nodeType, mesh/solution sizes — prefer the stdlib reader over a live
 JVM:
 
 ```python
-from sim.drivers.comsol.lib import inspect_mph
+from sim_plugin_comsol.lib import inspect_mph
 summary = inspect_mph(path)   # one-shot dict
 ```
 

--- a/src/sim_plugin_comsol/_skills/comsol/base/reference/mph_file_format.md
+++ b/src/sim_plugin_comsol/_skills/comsol/base/reference/mph_file_format.md
@@ -4,7 +4,7 @@
 
 ## Why this matters
 
-When an agent needs to answer "what's in this `.mph`?" — physics tags, parameters, mesh size, whether it's solved — the historical answer was "spin up a 2 GB JVM." For inspection-only queries that's overkill. The stdlib reader (`sim.drivers.comsol.lib.mph_inspect`) collapses these into sub-second calls and is auto-invoked by the driver's diagnostic probes.
+When an agent needs to answer "what's in this `.mph`?" — physics tags, parameters, mesh size, whether it's solved — the historical answer was "spin up a 2 GB JVM." For inspection-only queries that's overkill. The stdlib reader (`sim_plugin_comsol.lib.mph_inspect`) collapses these into sub-second calls and is auto-invoked by the driver's diagnostic probes.
 
 ## Archive layout
 
@@ -50,10 +50,10 @@ The `T="33"` siblings inside `<ModelParamGroup>` are the global parameters. **Ma
 
 ## Reading the file
 
-The driver ships `sim.drivers.comsol.lib.mph_inspect` with a stdlib-only API:
+The driver ships `sim_plugin_comsol.lib.mph_inspect` with a stdlib-only API:
 
 ```python
-from sim.drivers.comsol.lib import inspect_mph, MphArchive, mph_diff
+from sim_plugin_comsol.lib import inspect_mph, MphArchive, mph_diff
 
 # One-shot dict summary
 summary = inspect_mph("model.mph")
@@ -81,5 +81,5 @@ delta = mph_diff("before.mph", "after.mph")
 
 ## References
 
-- `sim-cli` source: [`src/sim/drivers/comsol/lib/mph_inspect.py`](https://github.com/svd-ai-lab/sim-cli/blob/main/src/sim/drivers/comsol/lib/mph_inspect.py)
+- Plugin source: [`src/sim_plugin_comsol/lib/mph_inspect.py`](https://github.com/svd-ai-lab/sim-plugin-comsol/blob/main/src/sim_plugin_comsol/lib/mph_inspect.py)
 - Reverse-engineering write-up: [sim-proj#51](https://github.com/svd-ai-lab/sim-proj/issues/51), [sim-cli#47](https://github.com/svd-ai-lab/sim-cli/pull/47)


### PR DESCRIPTION
## Summary

- Skill content still referenced the pre-extraction in-tree Python path `sim.drivers.comsol.lib`, which no longer exists after this plugin was extracted (#1). Replace with `sim_plugin_comsol.lib`.
- Files touched:
  - `src/sim_plugin_comsol/_skills/comsol/SKILL.md` (line 123)
  - `src/sim_plugin_comsol/_skills/comsol/base/reference/mph_file_format.md` (lines 7, 53, 56)
- Also fixed the trailing GitHub source URL on line 84 of `mph_file_format.md` to point at this plugin's repo (`sim-plugin-comsol`) rather than the old `sim-cli/src/sim/drivers/comsol/lib/...` location.

## Test plan

- [x] `grep -rn "sim.drivers.comsol" src/sim_plugin_comsol/_skills/` returns zero hits.
- [x] `grep -rn "sim/drivers/comsol" src/sim_plugin_comsol/_skills/` returns zero hits (stale URL also cleaned up).

Refs: extraction PR #1.