### PR TITLE
tests: add protocol conformance test

### DIFF
--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,0 +1,10 @@
+"""Protocol-conformance test — plugged into sim-cli's shared harness."""
+from __future__ import annotations
+
+from sim.testing import assert_protocol_conformance
+from sim_plugin_comsol import ComsolDriver
+
+
+def test_protocol_conformance() -> None:
+    """Drives every conformance check sim-cli requires of a plugin driver."""
+    assert_protocol_conformance(ComsolDriver)


### PR DESCRIPTION
Adds `tests/test_protocol.py`, mirroring the harness already shipped in `sim-plugin-coolprop` and `sim-plugin-openfoam`. The test drives `sim.testing.assert_protocol_conformance` against `ComsolDriver`.

Tracking: svd-ai-lab/sim-proj#74 (Phase 2B housekeeping).

No CI workflow added; no other files touched. `pytest` not run locally because `sim-cli` is not installed in the temp clone — conformance will run wherever sim-cli's shared harness picks it up.