### PR TITLE
[codex] Clarify COMSOL visual session modes

### DIFF
--- a/src/sim_plugin_comsol/_skills/comsol/SKILL.md
+++ b/src/sim_plugin_comsol/_skills/comsol/SKILL.md
@@ -176,30 +176,53 @@ value with a tolerance) per the shared skill's `acceptance.md`.
 
 ---
 
-## GUI actuation
+## GUI and visual inspection modes
 
-When launched with `ui_mode=gui` (the default), a `gui` object is
-injected into the `sim exec` namespace. `/connect` advertises it under
-`data.tools = ["gui"]`. See
-[`sim-skills/sim-cli/gui/SKILL.md`](../sim-cli/gui/SKILL.md) for the full
-API.
+COMSOL has several visual surfaces. Do not collapse them into one
+"GUI mode" in your reasoning or status reports:
 
-COMSOL-specific dialogs you will run into:
+| Mode | What it means | Live with agent edits? |
+|---|---|---|
+| `headless` | `comsolmphserver` API session with no intentional visible windows. | Yes, API session only. |
+| `server-graphics` | `comsolmphserver -graphics`; plot windows may appear when a result plot is run. This is the current default effective mode. Legacy `ui_mode=gui` is an alias for this. | Yes for the server-side model, but there is no Model Builder tree. |
+| `desktop-inspection` | Save a `.mph` artifact, then open it in full COMSOL Desktop / Model Builder. | No. It is an inspection copy unless explicitly reloaded. |
+| `shared-desktop` | Future target: full COMSOL Desktop attached to the same live server-side model. | Not implemented yet. |
 
-- **"连接到 COMSOL Multiphysics Server"** — pops every launch. Cortex
-  waits at the login page until dismissed even though the JPype
-  backend is already connected. **Dismiss in the first `sim exec`
-  after `sim connect`**:
-  `gui.find("连接到").click("确定")`. English-locale installs show
-  *"Connect to COMSOL"* — see
-  `../sim-cli/gui/snippets/dismiss_login_dialog.py` for a locale-robust
-  variant.
-- **"是否保存更改?"** / **"Save changes?"** — appears on disconnect
-  if the model has unsaved edits. Click **保存 / Save** or
-  **不保存 / Don't save** depending on intent before
-  `sim disconnect`.
+Use `sim inspect session.health` or `sim exec` target `session.health`
+to check `requested_ui_mode`, `effective_ui_mode`, `ui_capabilities`,
+PIDs, logs, and visible COMSOL window titles. Treat `model_builder_live:
+false` as authoritative: agent-side JPype edits will not automatically
+refresh a separately opened COMSOL Desktop window.
 
-Prefer the JPype path (`model.*`, `ModelUtil.*`) for anything
-programmable — `gui` is only for the desktop client's UI surface
-that has no Java equivalent (file pickers, license dialogs, the
-login prompt).
+### Screenshot responsibility
+
+On a Codex Desktop host such as Win1, prefer Codex's own desktop
+screenshot/view tools for visual verification. They see the same
+interactive desktop the user sees and avoid adding solver-specific
+screenshot commands to sim-cli. Use `sim screenshot` only when the
+solver GUI is on a remote host that Codex cannot directly capture.
+
+When you perform GUI-visible work, verify after every significant action:
+
+1. Launch or connect.
+2. Geometry build or import.
+3. Material assignment.
+4. Physics setup.
+5. Mesh build.
+6. Solve and result plot.
+7. Save/open `.mph` for Desktop inspection when Model Builder review is needed.
+
+### COMSOL-specific dialogs
+
+- **"连接到 COMSOL Multiphysics Server"** / **"Connect to COMSOL
+  Multiphysics Server"** may be a stale or separate Desktop/client
+  login dialog. It does not prove the JPype server session failed.
+  Verify by checking `session.health`, the port, PIDs, and visible
+  window titles.
+- **"是否保存更改?"** / **"Save changes?"** appears on Desktop close if
+  a separately opened `.mph` has unsaved edits. Choose Save or Don't Save
+  according to the user's intent.
+
+Prefer the JPype path (`model.*`, `ModelUtil.*`) for programmable model
+construction and solving. Use Desktop inspection only when a human needs
+to see the Model Builder tree or interact with file/dialog surfaces.

--- a/src/sim_plugin_comsol/driver.py
+++ b/src/sim_plugin_comsol/driver.py
@@ -64,6 +64,41 @@ class ComsolLifecycleError(RuntimeError):
         return " | ".join(bits)
 
 
+_COMSOL_UI_MODE_ALIASES = {
+    "": "server-graphics",
+    "gui": "server-graphics",
+    "visible": "server-graphics",
+    "graphics": "server-graphics",
+    "server_graphics": "server-graphics",
+    "server-graphics": "server-graphics",
+    "headless": "headless",
+    "none": "headless",
+    "desktop": "server-graphics",
+    "desktop-inspection": "server-graphics",
+}
+
+_COMSOL_UI_MODE_NOTES = {
+    "gui": (
+        "ui_mode='gui' is a legacy alias for server-graphics: COMSOL "
+        "server-side plot windows may appear, but full Model Builder is "
+        "not attached to the live session."
+    ),
+    "visible": "ui_mode='visible' is treated as server-graphics.",
+    "graphics": "ui_mode='graphics' is treated as server-graphics.",
+    "server_graphics": "ui_mode='server_graphics' is treated as server-graphics.",
+    "desktop": (
+        "ui_mode='desktop' is not a live shared Desktop mode yet. The "
+        "current launch uses server-graphics; save the .mph artifact and "
+        "open it in COMSOL Desktop for inspection."
+    ),
+    "desktop-inspection": (
+        "desktop-inspection is an artifact workflow, not a live session "
+        "mode. The current launch uses server-graphics; open the saved .mph "
+        "artifact in COMSOL Desktop for Model Builder inspection."
+    ),
+}
+
+
 # ── Channel #4 — default SDK attribute readers (COMSOL / MPh Model Java API) ──
 def _default_comsol_readers() -> list[tuple[str, object]]:
     """Each reader is (label, callable(session) -> value). The session is
@@ -673,6 +708,76 @@ class ComsolDriver:
             return "comsol.server.busy_timeout"
         return "comsol.modelutil.failure"
 
+    def _normalize_ui_mode(self, ui_mode: str | None) -> tuple[str, str | None]:
+        requested = (ui_mode or "").strip().lower()
+        effective = _COMSOL_UI_MODE_ALIASES.get(requested)
+        if effective is None:
+            valid = ", ".join(sorted(set(_COMSOL_UI_MODE_ALIASES.values())))
+            raise ValueError(
+                f"unknown COMSOL ui_mode={ui_mode!r}; expected one of: {valid}"
+            )
+        return effective, _COMSOL_UI_MODE_NOTES.get(requested)
+
+    def _ui_capabilities(self, effective_ui_mode: str | None = None) -> dict:
+        mode = effective_ui_mode or self._ui_mode or "headless"
+        server_graphics = mode == "server-graphics"
+        return {
+            "server_graphics": server_graphics,
+            "plot_windows": server_graphics,
+            "model_builder_live": False,
+            "desktop_inspection": "artifact",
+            "shared_desktop": False,
+            "screenshot_source": "codex-desktop-or-sim-remote",
+        }
+
+    def _visible_windows(self) -> list[dict]:
+        """Best-effort visible COMSOL windows for tracked server/client PIDs."""
+        if os.name != "nt":
+            return []
+
+        tracked = {
+            getattr(self._server_proc, "pid", None): "server",
+            getattr(self._client_proc, "pid", None): "client",
+        }
+        tracked.pop(None, None)
+        if not tracked:
+            return []
+
+        try:
+            import ctypes
+            import ctypes.wintypes
+
+            user32 = ctypes.windll.user32
+            windows: list[dict] = []
+
+            @ctypes.WINFUNCTYPE(
+                ctypes.wintypes.BOOL,
+                ctypes.wintypes.HWND,
+                ctypes.wintypes.LPARAM,
+            )
+            def enum_window(hwnd, _lparam):
+                if not user32.IsWindowVisible(hwnd):
+                    return True
+                pid = ctypes.wintypes.DWORD()
+                user32.GetWindowThreadProcessId(hwnd, ctypes.byref(pid))
+                role = tracked.get(int(pid.value))
+                if role is None:
+                    return True
+                title = ctypes.create_unicode_buffer(512)
+                user32.GetWindowTextW(hwnd, title, 512)
+                if title.value:
+                    windows.append({
+                        "pid": int(pid.value),
+                        "role": role,
+                        "title": title.value,
+                    })
+                return True
+
+            user32.EnumWindows(enum_window, 0)
+            return windows
+        except Exception:
+            return []
+
     def health(self) -> dict:
         """Best-effort live-session health for `session.summary` / diagnostics."""
         server_returncode = self._server_proc.poll() if self._server_proc is not None else None
@@ -718,6 +823,10 @@ class ComsolDriver:
             "message": message,
             "session_id": self._session_id,
             "ui_mode": self._ui_mode,
+            "requested_ui_mode": self._launch_options.get("requested_ui_mode"),
+            "effective_ui_mode": self._ui_mode,
+            "ui_note": self._launch_options.get("ui_note"),
+            "ui_capabilities": self._ui_capabilities(),
             "port": self._port,
             "server_pid": getattr(self._server_proc, "pid", None),
             "server_running": server_running,
@@ -729,6 +838,7 @@ class ComsolDriver:
             "client_log_path": str(self._client_log_path) if self._client_log_path else None,
             "modelutil_connected": modelutil_connected,
             "model_tags": model_tags,
+            "windows": self._visible_windows(),
             "last_disconnect_reason": self._last_disconnect_reason,
             "launch_options": self._launch_options,
         }
@@ -738,6 +848,28 @@ class ComsolDriver:
     def query(self, name: str) -> dict:
         if name in {"health", "session.health"}:
             return self.health()
+        if name in {"ui.modes", "session.ui_modes"}:
+            return {
+                "ok": True,
+                "modes": {
+                    "headless": "COMSOL server API session without intentional visible UI.",
+                    "server-graphics": (
+                        "COMSOL server API session with server-side graphics; "
+                        "plot windows may be visible, but Model Builder is not "
+                        "attached live."
+                    ),
+                    "desktop-inspection": (
+                        "Save the .mph artifact, then open it in full COMSOL "
+                        "Desktop for Model Builder inspection. This is not "
+                        "live-synchronized with the server session."
+                    ),
+                    "shared-desktop": (
+                        "Future mode: full COMSOL Desktop attached to the same "
+                        "live server-side model."
+                    ),
+                },
+                "aliases": dict(_COMSOL_UI_MODE_ALIASES),
+            }
         return {"ok": False, "error": f"unknown inspect target: {name}"}
 
     def _check_port(self, port: int, timeout: float = 2) -> bool:
@@ -771,18 +903,22 @@ class ComsolDriver:
         password: str | None = None,
         **kwargs,
     ) -> dict:
-        """Launch comsolmphserver + optional GUI client, connect via JPype.
+        """Launch comsolmphserver and connect via JPype.
 
         1. Start `comsolmphserver.exe` as compute backend
         2. Wait for it to listen on the port
         3. Connect via `ModelUtil.connect()` from JPype
-        4. If ui_mode == 'gui', launch `comsolmphclient.exe` (visual GUI attached)
+        4. If ui_mode resolves to 'server-graphics', keep COMSOL server-side
+           graphics enabled so plot windows can appear. This is not a live
+           Model Builder desktop attachment.
         """
         import subprocess
 
         workspace = kwargs.pop("workspace", None)
         cwd = kwargs.pop("cwd", None)
         port = kwargs.pop("port", None)
+        requested_ui_mode = ui_mode
+        effective_ui_mode, ui_note = self._normalize_ui_mode(ui_mode)
         if port is not None:
             self._port = int(port)
         self._session_id = str(uuid.uuid4())
@@ -795,14 +931,15 @@ class ComsolDriver:
         password = password or os.environ.get("COMSOL_PASSWORD", "")
         bin_dir = os.path.join(root, "bin", "win64")
         server_exe = os.path.join(bin_dir, "comsolmphserver.exe")
-        client_exe = os.path.join(bin_dir, "comsolmphclient.exe")
 
         if not os.path.isfile(server_exe):
             raise RuntimeError(f"comsolmphserver not found at {server_exe}")
 
         self._launch_options = {
             "mode": mode,
-            "ui_mode": ui_mode,
+            "requested_ui_mode": requested_ui_mode,
+            "ui_mode": effective_ui_mode,
+            "ui_note": ui_note,
             "processors": processors,
             "comsol_root": root,
             "workspace": workspace,
@@ -821,9 +958,17 @@ class ComsolDriver:
             raise err
 
         # -login auto: use cached credentials set via `comsolmphserver -login force`
+        server_args = [
+            server_exe,
+            "-port", str(self._port),
+            "-multi", "on",
+            "-login", "auto",
+            "-silent",
+        ]
+        if effective_ui_mode == "server-graphics":
+            server_args += ["-graphics", "-3drend", "sw"]
         self._server_proc = subprocess.Popen(
-            [server_exe, "-port", str(self._port), "-multi", "on",
-             "-login", "auto", "-silent", "-graphics", "-3drend", "sw"],
+            server_args,
             stdout=self._server_log_handle,
             stderr=subprocess.STDOUT,
         )
@@ -880,39 +1025,6 @@ class ComsolDriver:
         ModelUtil.setServerBusyHandler(ServerBusyHandler(30000))
         self._model_util = ModelUtil
 
-        if ui_mode in ("gui", "desktop") and os.path.isfile(client_exe):
-            client_args = [client_exe, "-port", str(self._port), "-login", "auto"]
-            cs_user = os.environ.get("COMSOL_USER")
-            cs_pass = os.environ.get("COMSOL_PASSWORD")
-            if cs_user and cs_pass:
-                client_args += ["-username", cs_user, "-password", cs_pass]
-            self._client_log_path, self._client_log_handle = self._open_log("comsol-mphclient")
-            self._client_proc = subprocess.Popen(
-                client_args,
-                stdout=self._client_log_handle,
-                stderr=subprocess.STDOUT,
-            )
-            # The GUI client shows a "Connect to COMSOL Server" login dialog on
-            # startup before it creates an Untitled model. This dialog blocks
-            # ModelUtil.tags() from returning anything — causing a deadlock:
-            # launch() polls for tags while the dialog waits for a click that
-            # only comes after launch() returns. Fix: dismiss the dialog here,
-            # before we start polling tags.
-            from sim.gui import GuiController  # noqa: PLC0415
-            _preflight_gui = GuiController(
-                process_name_substrings=self.GUI_PROCESS_FILTER,
-                workdir=str(self._sim_dir),
-            )
-            _dlg = _preflight_gui.find(title_contains="连接到", timeout_s=10)
-            if _dlg is None:
-                _dlg = _preflight_gui.find(title_contains="Connect to COMSOL", timeout_s=3)
-            if _dlg is not None:
-                for _btn in ("确定", "OK"):
-                    _r = _dlg.click(_btn)
-                    if _r.get("ok"):
-                        break
-                _preflight_gui.wait_until_window_gone("连接到", timeout_s=10)
-
         # Create model. Guard against the server surviving a previous
         # disconnect(): if "Model1" already exists on the server, that tag
         # belongs to a stale session — remove it first, then create fresh.
@@ -943,15 +1055,15 @@ class ComsolDriver:
             self._close_log_handles()
             raise err from exc
 
-        self._ui_mode = ui_mode
+        self._ui_mode = effective_ui_mode
         self._connected_at = time.time()
         self._run_count = 0
         self._last_run = None
         self._last_health = self.health()
 
         # Flip probes to GUI-aware variant + construct gui actuation facade
-        # when the client window is actually up. Headless launches skip both.
-        gui_mode = ui_mode in ("gui", "desktop")
+        # when server-side graphics may show windows. Headless launches skip both.
+        gui_mode = effective_ui_mode == "server-graphics"
         if gui_mode:
             self.probes = _default_comsol_probes(enable_gui=True)
             from sim.gui import GuiController  # noqa: PLC0415
@@ -965,7 +1077,11 @@ class ComsolDriver:
             "session_id": self._session_id,
             "mode": "client-server",
             "source": "launch",
-            "ui_mode": ui_mode,
+            "requested_ui_mode": requested_ui_mode,
+            "ui_mode": effective_ui_mode,
+            "effective_ui_mode": effective_ui_mode,
+            "ui_note": ui_note,
+            "ui_capabilities": self._ui_capabilities(effective_ui_mode),
             "port": self._port,
             "model_tag": str(self._model.tag()),
             "server_log_path": str(self._server_log_path) if self._server_log_path else None,

--- a/tests/test_comsol_driver.py
+++ b/tests/test_comsol_driver.py
@@ -153,6 +153,22 @@ class TestRunFile:
 
 
 class TestLifecycleDiagnostics:
+    def test_legacy_gui_mode_is_server_graphics_alias(self):
+        driver = ComsolDriver()
+
+        effective, note = driver._normalize_ui_mode("gui")
+
+        assert effective == "server-graphics"
+        assert "legacy alias" in note
+
+    def test_desktop_mode_is_not_reported_as_live_desktop(self):
+        driver = ComsolDriver()
+
+        effective, note = driver._normalize_ui_mode("desktop")
+
+        assert effective == "server-graphics"
+        assert "not a live shared Desktop mode yet" in note
+
     def test_wait_for_port_reports_early_server_exit_with_log_tail(self, tmp_path):
         driver = ComsolDriver()
         driver._sim_dir = tmp_path / ".sim"
@@ -187,6 +203,38 @@ class TestLifecycleDiagnostics:
         assert health["code"] == "comsol.server.process_exited"
         assert health["server_pid"] == 2468
         assert health["server_returncode"] == 9
+        assert health["effective_ui_mode"] is None
+        assert health["ui_capabilities"]["model_builder_live"] is False
+
+    def test_health_reports_ui_metadata_and_windows(self, monkeypatch):
+        driver = ComsolDriver()
+        driver._session_id = "s-test"
+        driver._model = object()
+        driver._server_proc = FakeProcess(pid=2468, returncode=None)
+        driver._port = 65000
+        driver._ui_mode = "server-graphics"
+        driver._launch_options = {
+            "requested_ui_mode": "gui",
+            "ui_mode": "server-graphics",
+            "ui_note": "legacy alias",
+        }
+        monkeypatch.setattr(driver, "_check_port", lambda *_args, **_kwargs: True)
+        monkeypatch.setattr(
+            driver,
+            "_visible_windows",
+            lambda: [{"pid": 2468, "role": "server", "title": "Plot 1"}],
+        )
+
+        health = driver.health()
+
+        assert health["connected"] is True
+        assert health["requested_ui_mode"] == "gui"
+        assert health["effective_ui_mode"] == "server-graphics"
+        assert health["ui_capabilities"]["plot_windows"] is True
+        assert health["ui_capabilities"]["model_builder_live"] is False
+        assert health["windows"] == [
+            {"pid": 2468, "role": "server", "title": "Plot 1"}
+        ]
 
     def test_query_session_health(self):
         driver = ComsolDriver()
@@ -196,6 +244,16 @@ class TestLifecycleDiagnostics:
         assert health["ok"] is False
         assert health["connected"] is False
         assert health["code"] == "comsol.session.disconnected"
+
+    def test_query_ui_modes(self):
+        driver = ComsolDriver()
+
+        modes = driver.query("ui.modes")
+
+        assert modes["ok"] is True
+        assert "server-graphics" in modes["modes"]
+        assert "shared-desktop" in modes["modes"]
+        assert modes["aliases"]["gui"] == "server-graphics"
 
 
 def _make_import_blocker(blocked: str):


### PR DESCRIPTION
## Summary

- Treat legacy `ui_mode="gui"` as an explicit `server-graphics` alias instead of launching a misleading `comsolmphclient` desktop flow.
- Add COMSOL session health metadata for requested/effective UI mode, capabilities, visible COMSOL windows, and UI notes.
- Document the distinction between headless, server-graphics, desktop inspection, and future shared desktop modes in the bundled COMSOL skill.

## Why

The HBM GUI demo showed that COMSOL server-side plot windows are useful, but they are not the full Model Builder desktop. The plugin now reports that distinction directly so agents and users do not mistake plot-window mode for live Desktop collaboration.

## Validation

- `PYTHONIOENCODING=utf-8 .\.venv\Scripts\python.exe -m pytest --basetemp .pytest_basetemp\p0_all`
- Real COMSOL smoke: `ui_mode="headless"` launch/health/disconnect on port 2050
- Real COMSOL smoke: `ui_mode="server-graphics"` launch/health/disconnect on port 2051
- Real COMSOL smoke: legacy `ui_mode="gui"` reports `effective_ui_mode="server-graphics"`, no client PID, and disconnects cleanly on port 2052

## Notes

The generic sim-cli side is already covered by the existing `codex/generic-driver-options` branch, so this PR stays scoped to COMSOL plugin semantics and docs.
