### PR TITLE
[codex] Implement COMSOL shared desktop and attach-only modes

### DIFF
--- a/src/sim_plugin_comsol/_skills/comsol/SKILL.md
+++ b/src/sim_plugin_comsol/_skills/comsol/SKILL.md
@@ -186,7 +186,7 @@ COMSOL has several visual surfaces. Do not collapse them into one
 | `headless` | `comsolmphserver` API session with no intentional visible windows. | Yes, API session only. |
 | `server-graphics` | `comsolmphserver -graphics`; plot windows may appear when a result plot is run. This is the current default effective mode. Legacy `ui_mode=gui` is an alias for this. | Yes for the server-side model, but there is no Model Builder tree. |
 | `desktop-inspection` | Save a `.mph` artifact, then open it in full COMSOL Desktop / Model Builder. | No. It is an inspection copy unless explicitly reloaded. |
-| `shared-desktop` | Future target: full COMSOL Desktop attached to the same server, with the agent binding to the Desktop's active model tag. | Not implemented yet, but validated manually on Win1. |
+| `shared-desktop` | Full COMSOL Desktop attached to the same server, with the agent binding to the Desktop's active model tag. Request from sim-cli with `--driver-option visual_mode=shared-desktop`. | Yes, when `model_builder_live: true`. |
 
 Use `sim inspect session.health` or `sim exec` target `session.health`
 to check `requested_ui_mode`, `effective_ui_mode`, `ui_capabilities`,
@@ -201,9 +201,20 @@ server model tag with `ModelUtil.create("SharedProbe")`, the Desktop
 does not automatically switch from its active `Model1` tree to that
 new tag. When JPype instead mutates `ModelUtil.model("Model1")`, the
 Desktop refreshes: the title, Model Builder tree, and Graphics view
-show the API-created component/geometry. A production
-`shared-desktop` mode must therefore discover or negotiate the active
-Desktop model tag and route agent edits to that tag.
+show the API-created component/geometry. The implemented
+`shared-desktop` mode therefore discovers or negotiates the active
+Desktop model tag and routes agent edits to that tag.
+
+Use:
+
+```powershell
+sim connect --solver comsol --ui-mode gui --driver-option visual_mode=shared-desktop
+```
+
+Then verify `session.health`: `effective_ui_mode` should be
+`shared-desktop`, `ui_capabilities.model_builder_live` should be `true`,
+and `active_model_tag` should name the model that agent snippets will
+mutate.
 
 ### Screenshot responsibility
 

--- a/src/sim_plugin_comsol/_skills/comsol/SKILL.md
+++ b/src/sim_plugin_comsol/_skills/comsol/SKILL.md
@@ -186,13 +186,24 @@ COMSOL has several visual surfaces. Do not collapse them into one
 | `headless` | `comsolmphserver` API session with no intentional visible windows. | Yes, API session only. |
 | `server-graphics` | `comsolmphserver -graphics`; plot windows may appear when a result plot is run. This is the current default effective mode. Legacy `ui_mode=gui` is an alias for this. | Yes for the server-side model, but there is no Model Builder tree. |
 | `desktop-inspection` | Save a `.mph` artifact, then open it in full COMSOL Desktop / Model Builder. | No. It is an inspection copy unless explicitly reloaded. |
-| `shared-desktop` | Future target: full COMSOL Desktop attached to the same live server-side model. | Not implemented yet. |
+| `shared-desktop` | Future target: full COMSOL Desktop attached to the same server, with the agent binding to the Desktop's active model tag. | Not implemented yet, but validated manually on Win1. |
 
 Use `sim inspect session.health` or `sim exec` target `session.health`
 to check `requested_ui_mode`, `effective_ui_mode`, `ui_capabilities`,
 PIDs, logs, and visible COMSOL window titles. Treat `model_builder_live:
 false` as authoritative: agent-side JPype edits will not automatically
 refresh a separately opened COMSOL Desktop window.
+
+Shared-desktop gotcha verified on Win1 with COMSOL 6.4: launching
+`comsol.exe mphclient -host localhost -port <port>` does attach a full
+Desktop to `comsolmphserver`. However, if JPype creates a separate
+server model tag with `ModelUtil.create("SharedProbe")`, the Desktop
+does not automatically switch from its active `Model1` tree to that
+new tag. When JPype instead mutates `ModelUtil.model("Model1")`, the
+Desktop refreshes: the title, Model Builder tree, and Graphics view
+show the API-created component/geometry. A production
+`shared-desktop` mode must therefore discover or negotiate the active
+Desktop model tag and route agent edits to that tag.
 
 ### Screenshot responsibility
 

--- a/src/sim_plugin_comsol/_skills/comsol/SKILL.md
+++ b/src/sim_plugin_comsol/_skills/comsol/SKILL.md
@@ -216,6 +216,32 @@ Then verify `session.health`: `effective_ui_mode` should be
 and `active_model_tag` should name the model that agent snippets will
 mutate.
 
+### Attach-only external server
+
+If repeated API client disconnects occur, or a user wants one COMSOL
+server to survive multiple sim sessions, use an externally managed server
+instead of mixing sim and ad hoc JPype scripts. The user or agent starts
+`comsolmphserver` first in an interactive Windows shell:
+
+```powershell
+& "C:\Program Files\COMSOL\COMSOL64\Multiphysics\bin\win64\comsolmphserver.exe" -port 2036 -multi on -login auto -silent
+```
+
+Then connect through sim with explicit attach-only ownership:
+
+```powershell
+sim connect --solver comsol --ui-mode gui `
+  --driver-option attach_only=true `
+  --driver-option port=2036 `
+  --driver-option visual_mode=shared-desktop
+```
+
+In attach-only mode, `session.health` should show
+`server_owner: "external"` and `attach_only: true`. `sim disconnect`
+disconnects the JPype client and any plugin-launched Desktop client, but
+does not kill the external `comsolmphserver`. Keep all agent operations
+inside the sim session; use ad hoc JPype only as a diagnostic escape hatch.
+
 ### Screenshot responsibility
 
 On a Codex Desktop host such as Win1, prefer Codex's own desktop

--- a/src/sim_plugin_comsol/driver.py
+++ b/src/sim_plugin_comsol/driver.py
@@ -73,8 +73,23 @@ _COMSOL_UI_MODE_ALIASES = {
     "server-graphics": "server-graphics",
     "headless": "headless",
     "none": "headless",
+    "shared_desktop": "shared-desktop",
+    "shared-desktop": "shared-desktop",
     "desktop": "server-graphics",
     "desktop-inspection": "server-graphics",
+}
+
+_COMSOL_VISUAL_MODE_ALIASES = {
+    "": None,
+    "default": None,
+    "auto": None,
+    "server_graphics": "server-graphics",
+    "server-graphics": "server-graphics",
+    "graphics": "server-graphics",
+    "shared": "shared-desktop",
+    "shared_desktop": "shared-desktop",
+    "shared-desktop": "shared-desktop",
+    "desktop": "shared-desktop",
 }
 
 _COMSOL_UI_MODE_NOTES = {
@@ -95,6 +110,14 @@ _COMSOL_UI_MODE_NOTES = {
         "desktop-inspection is an artifact workflow, not a live session "
         "mode. The current launch uses server-graphics; open the saved .mph "
         "artifact in COMSOL Desktop for Model Builder inspection."
+    ),
+    "shared_desktop": (
+        "ui_mode='shared_desktop' launches shared-desktop mode; prefer "
+        "--driver-option visual_mode=shared-desktop from sim-cli."
+    ),
+    "shared-desktop": (
+        "ui_mode='shared-desktop' launches shared-desktop mode; prefer "
+        "--driver-option visual_mode=shared-desktop from sim-cli."
     ),
 }
 
@@ -426,6 +449,8 @@ class ComsolDriver:
         self._client_log_handle: TextIO | None = None
         self._server_log_path: Path | None = None
         self._client_log_path: Path | None = None
+        self._desktop_pid: int | None = None
+        self._active_model_tag: str | None = None
         self._last_health: dict | None = None
         self._last_disconnect_reason: dict | None = None
         self._launch_options: dict = {}
@@ -641,6 +666,8 @@ class ComsolDriver:
                 setattr(self, attr, None)
 
     def _terminate_processes(self) -> None:
+        self._kill_pid(self._desktop_pid)
+        self._desktop_pid = None
         for attr in ("_client_proc", "_server_proc"):
             proc = getattr(self, attr, None)
             if proc is None:
@@ -687,6 +714,7 @@ class ComsolDriver:
             "client_returncode": client_returncode,
             "client_log_path": str(self._client_log_path) if self._client_log_path else None,
             "client_log_tail": self._tail_file(self._client_log_path),
+            "desktop_pid": self._desktop_pid,
         }
 
     def _lifecycle_error(self, code: str, message: str) -> ComsolLifecycleError:
@@ -718,19 +746,144 @@ class ComsolDriver:
             )
         return effective, _COMSOL_UI_MODE_NOTES.get(requested)
 
+    def _resolve_visual_mode(
+        self,
+        ui_mode: str | None,
+        visual_mode: str | None,
+    ) -> tuple[str, str | None, str | None]:
+        effective, note = self._normalize_ui_mode(ui_mode)
+        requested = (visual_mode or "").strip().lower()
+        visual = _COMSOL_VISUAL_MODE_ALIASES.get(requested)
+        if requested and requested not in _COMSOL_VISUAL_MODE_ALIASES:
+            valid = ", ".join(sorted(k for k in _COMSOL_VISUAL_MODE_ALIASES if k))
+            raise ValueError(
+                f"unknown COMSOL visual_mode={visual_mode!r}; expected one of: {valid}"
+            )
+        if visual is None:
+            return effective, note, None
+        if visual == "server-graphics":
+            return "server-graphics", "visual_mode='server-graphics' requested.", visual
+        if visual == "shared-desktop":
+            return (
+                "shared-desktop",
+                "visual_mode='shared-desktop' attaches COMSOL Desktop to the live server "
+                "and routes agent edits to the Desktop active model tag.",
+                visual,
+            )
+        return effective, note, visual
+
     def _ui_capabilities(self, effective_ui_mode: str | None = None) -> dict:
         mode = effective_ui_mode or self._ui_mode or "headless"
         server_graphics = mode == "server-graphics"
+        shared_desktop = mode == "shared-desktop"
         return {
             "server_graphics": server_graphics,
-            "plot_windows": server_graphics,
-            "model_builder_live": False,
-            "desktop_inspection": "artifact",
-            "shared_desktop": False,
+            "plot_windows": server_graphics or shared_desktop,
+            "model_builder_live": shared_desktop,
+            "desktop_inspection": "live" if shared_desktop else "artifact",
+            "shared_desktop": shared_desktop,
             "screenshot_source": "codex-desktop-or-sim-remote",
         }
 
-    def _visible_windows(self) -> list[dict]:
+    def _windows_process_rows(self) -> list[dict]:
+        if os.name != "nt":
+            return []
+        import csv
+        import subprocess
+
+        try:
+            result = subprocess.run(
+                ["tasklist", "/fo", "csv", "/nh"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except OSError:
+            return []
+        if result.returncode != 0:
+            return []
+        rows: list[dict] = []
+        for row in csv.reader(result.stdout.splitlines()):
+            if len(row) < 2:
+                continue
+            try:
+                pid = int(row[1])
+            except ValueError:
+                continue
+            rows.append({"name": row[0], "pid": pid})
+        return rows
+
+    def _comsol_process_pids(self) -> set[int]:
+        pids: set[int] = set()
+        for row in self._windows_process_rows():
+            name = str(row.get("name", "")).lower()
+            if any(part in name for part in self.GUI_PROCESS_FILTER):
+                pids.add(int(row["pid"]))
+        return pids
+
+    def _kill_pid(self, pid: int | None) -> None:
+        if pid is None:
+            return
+        if os.name == "nt":
+            import subprocess
+
+            subprocess.run(
+                ["taskkill", "/PID", str(pid), "/T", "/F"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+            )
+            return
+        try:
+            os.kill(pid, 9)
+        except OSError:
+            pass
+
+    def _start_desktop_client(
+        self,
+        bin_dir: str,
+        before_pids: set[int] | None = None,
+        timeout_s: float = 45,
+    ) -> None:
+        import subprocess
+
+        client_exe = os.path.join(bin_dir, "comsol.exe")
+        if not os.path.isfile(client_exe):
+            raise RuntimeError(f"COMSOL Desktop launcher not found at {client_exe}")
+
+        self._client_log_path, self._client_log_handle = self._open_log("comsol-mphclient")
+        client_args = [
+            client_exe,
+            "mphclient",
+            "-host",
+            "localhost",
+            "-port",
+            str(self._port),
+        ]
+        self._client_proc = subprocess.Popen(
+            client_args,
+            stdout=self._client_log_handle,
+            stderr=subprocess.STDOUT,
+        )
+
+        before_pids = before_pids or set()
+        deadline = time.time() + timeout_s
+        while time.time() < deadline:
+            for window in self._visible_windows(include_untracked_comsol=True):
+                pid = int(window.get("pid") or 0)
+                title = str(window.get("title") or "")
+                if pid in before_pids:
+                    continue
+                if "COMSOL Multiphysics" in title:
+                    self._desktop_pid = pid
+                    return
+            time.sleep(1)
+
+        # The launcher commonly exits after spawning ComsolUI.exe; an already
+        # open port and later health check can still prove the session. Keep
+        # going, but expose the missing Desktop PID in health.
+
+    def _visible_windows(self, include_untracked_comsol: bool = False) -> list[dict]:
         """Best-effort visible COMSOL windows for tracked server/client PIDs."""
         if os.name != "nt":
             return []
@@ -738,9 +891,14 @@ class ComsolDriver:
         tracked = {
             getattr(self._server_proc, "pid", None): "server",
             getattr(self._client_proc, "pid", None): "client",
+            self._desktop_pid: "desktop",
         }
         tracked.pop(None, None)
-        if not tracked:
+        process_names = {
+            int(row["pid"]): str(row["name"]).lower()
+            for row in self._windows_process_rows()
+        }
+        if not tracked and not include_untracked_comsol:
             return []
 
         try:
@@ -761,15 +919,20 @@ class ComsolDriver:
                 pid = ctypes.wintypes.DWORD()
                 user32.GetWindowThreadProcessId(hwnd, ctypes.byref(pid))
                 role = tracked.get(int(pid.value))
-                if role is None:
+                if role is None and not include_untracked_comsol:
                     return True
                 title = ctypes.create_unicode_buffer(512)
                 user32.GetWindowTextW(hwnd, title, 512)
-                if title.value:
+                process_name = process_names.get(int(pid.value), "")
+                if role is None and include_untracked_comsol:
+                    if any(part in process_name for part in self.GUI_PROCESS_FILTER):
+                        role = "desktop" if "comsolui" in process_name else "comsol"
+                if title.value and role is not None:
                     windows.append({
                         "pid": int(pid.value),
                         "role": role,
                         "title": title.value,
+                        "process": process_name,
                     })
                 return True
 
@@ -835,9 +998,11 @@ class ComsolDriver:
             "server_log_tail": self._tail_file(self._server_log_path) if not connected else None,
             "client_pid": getattr(self._client_proc, "pid", None),
             "client_returncode": client_returncode,
+            "desktop_pid": self._desktop_pid,
             "client_log_path": str(self._client_log_path) if self._client_log_path else None,
             "modelutil_connected": modelutil_connected,
             "model_tags": model_tags,
+            "active_model_tag": self._active_model_tag,
             "windows": self._visible_windows(),
             "last_disconnect_reason": self._last_disconnect_reason,
             "launch_options": self._launch_options,
@@ -864,8 +1029,8 @@ class ComsolDriver:
                         "live-synchronized with the server session."
                     ),
                     "shared-desktop": (
-                        "Future mode: full COMSOL Desktop attached to the same "
-                        "live server-side model."
+                        "Full COMSOL Desktop attached to the same server, with "
+                        "agent edits routed to the Desktop active model tag."
                     ),
                 },
                 "aliases": dict(_COMSOL_UI_MODE_ALIASES),
@@ -909,22 +1074,30 @@ class ComsolDriver:
         2. Wait for it to listen on the port
         3. Connect via `ModelUtil.connect()` from JPype
         4. If ui_mode resolves to 'server-graphics', keep COMSOL server-side
-           graphics enabled so plot windows can appear. This is not a live
-           Model Builder desktop attachment.
+           graphics enabled so plot windows can appear. If visual_mode resolves
+           to 'shared-desktop', launch COMSOL Desktop and bind the driver to
+           the Desktop active model tag.
         """
         import subprocess
 
         workspace = kwargs.pop("workspace", None)
         cwd = kwargs.pop("cwd", None)
         port = kwargs.pop("port", None)
+        visual_mode = kwargs.pop("visual_mode", None)
+        desktop_timeout = float(kwargs.pop("desktop_timeout", 45))
         requested_ui_mode = ui_mode
-        effective_ui_mode, ui_note = self._normalize_ui_mode(ui_mode)
+        effective_ui_mode, ui_note, normalized_visual_mode = self._resolve_visual_mode(
+            ui_mode,
+            visual_mode,
+        )
         if port is not None:
             self._port = int(port)
         self._session_id = str(uuid.uuid4())
         self._configure_workdir(workspace=workspace, cwd=cwd)
         self._last_health = None
         self._last_disconnect_reason = None
+        self._desktop_pid = None
+        self._active_model_tag = None
 
         root = self._resolve_comsol_root(comsol_root)
         user = user or os.environ.get("COMSOL_USER", "")
@@ -940,6 +1113,9 @@ class ComsolDriver:
             "requested_ui_mode": requested_ui_mode,
             "ui_mode": effective_ui_mode,
             "ui_note": ui_note,
+            "requested_visual_mode": visual_mode,
+            "visual_mode": normalized_visual_mode,
+            "desktop_timeout": desktop_timeout,
             "processors": processors,
             "comsol_root": root,
             "workspace": workspace,
@@ -967,6 +1143,7 @@ class ComsolDriver:
         ]
         if effective_ui_mode == "server-graphics":
             server_args += ["-graphics", "-3drend", "sw"]
+        before_comsol_pids = self._comsol_process_pids()
         self._server_proc = subprocess.Popen(
             server_args,
             stdout=self._server_log_handle,
@@ -1025,35 +1202,79 @@ class ComsolDriver:
         ModelUtil.setServerBusyHandler(ServerBusyHandler(30000))
         self._model_util = ModelUtil
 
-        # Create model. Guard against the server surviving a previous
-        # disconnect(): if "Model1" already exists on the server, that tag
-        # belongs to a stale session — remove it first, then create fresh.
-        # Fallback: if removal is refused, create with a session-unique name
-        # so we never conflict.
-        _model_tag = "Model1"
-        try:
+        if effective_ui_mode == "shared-desktop":
             try:
-                self._model = ModelUtil.create(_model_tag)
-            except Exception:
-                for _stale in list(ModelUtil.tags()):
-                    try:
-                        ModelUtil.remove(_stale)
-                    except Exception:
-                        pass
+                self._start_desktop_client(
+                    bin_dir,
+                    before_pids=before_comsol_pids,
+                    timeout_s=desktop_timeout,
+                )
+            except Exception as exc:  # noqa: BLE001 - Desktop launch failures vary
+                err = self._lifecycle_error(
+                    "comsol.desktop.launch_failed",
+                    f"failed to launch COMSOL Desktop client: {exc}",
+                )
+                self._terminate_processes()
+                self._close_log_handles()
+                raise err from exc
+
+            deadline = time.time() + desktop_timeout
+            _model_tag = "Model1"
+            while time.time() < deadline:
+                tags = [str(tag) for tag in list(ModelUtil.tags())]
+                if _model_tag in tags:
+                    break
+                if tags:
+                    _model_tag = tags[0]
+                    break
+                time.sleep(1)
+            try:
+                tags = [str(tag) for tag in list(ModelUtil.tags())]
+                if _model_tag in tags:
+                    self._model = ModelUtil.model(_model_tag)
+                else:
+                    self._model = ModelUtil.create(_model_tag)
+                self._active_model_tag = str(self._model.tag())
+            except Exception as exc:  # noqa: BLE001 - Java exceptions vary by version
+                code = self._classify_comsol_error(str(exc))
+                err = self._lifecycle_error(
+                    code,
+                    f"failed to bind shared Desktop model tag {_model_tag!r}: {exc}",
+                )
+                self._terminate_processes()
+                self._close_log_handles()
+                raise err from exc
+        else:
+            # Create model. Guard against the server surviving a previous
+            # disconnect(): if "Model1" already exists on the server, that tag
+            # belongs to a stale session — remove it first, then create fresh.
+            # Fallback: if removal is refused, create with a session-unique name
+            # so we never conflict.
+            _model_tag = "Model1"
+            try:
                 try:
                     self._model = ModelUtil.create(_model_tag)
                 except Exception:
-                    _model_tag = f"Model_{uuid.uuid4().hex[:6]}"
-                    self._model = ModelUtil.create(_model_tag)
-        except Exception as exc:  # noqa: BLE001 - Java exceptions vary by version
-            code = self._classify_comsol_error(str(exc))
-            err = self._lifecycle_error(
-                code,
-                f"ModelUtil.create failed: {exc}",
-            )
-            self._terminate_processes()
-            self._close_log_handles()
-            raise err from exc
+                    for _stale in list(ModelUtil.tags()):
+                        try:
+                            ModelUtil.remove(_stale)
+                        except Exception:
+                            pass
+                    try:
+                        self._model = ModelUtil.create(_model_tag)
+                    except Exception:
+                        _model_tag = f"Model_{uuid.uuid4().hex[:6]}"
+                        self._model = ModelUtil.create(_model_tag)
+                self._active_model_tag = str(self._model.tag())
+            except Exception as exc:  # noqa: BLE001 - Java exceptions vary by version
+                code = self._classify_comsol_error(str(exc))
+                err = self._lifecycle_error(
+                    code,
+                    f"ModelUtil.create failed: {exc}",
+                )
+                self._terminate_processes()
+                self._close_log_handles()
+                raise err from exc
 
         self._ui_mode = effective_ui_mode
         self._connected_at = time.time()
@@ -1062,8 +1283,8 @@ class ComsolDriver:
         self._last_health = self.health()
 
         # Flip probes to GUI-aware variant + construct gui actuation facade
-        # when server-side graphics may show windows. Headless launches skip both.
-        gui_mode = effective_ui_mode == "server-graphics"
+        # when visible COMSOL windows may appear. Headless launches skip both.
+        gui_mode = effective_ui_mode in {"server-graphics", "shared-desktop"}
         if gui_mode:
             self.probes = _default_comsol_probes(enable_gui=True)
             from sim.gui import GuiController  # noqa: PLC0415
@@ -1084,6 +1305,8 @@ class ComsolDriver:
             "ui_capabilities": self._ui_capabilities(effective_ui_mode),
             "port": self._port,
             "model_tag": str(self._model.tag()),
+            "active_model_tag": self._active_model_tag,
+            "desktop_pid": self._desktop_pid,
             "server_log_path": str(self._server_log_path) if self._server_log_path else None,
             "client_log_path": str(self._client_log_path) if self._client_log_path else None,
             "launch_options": self._launch_options,

--- a/src/sim_plugin_comsol/driver.py
+++ b/src/sim_plugin_comsol/driver.py
@@ -142,6 +142,14 @@ def _default_comsol_readers() -> list[tuple[str, object]]:
     ]
 
 
+def _as_bool(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
 def _default_comsol_probes(enable_gui: bool = False) -> list:
     """COMSOL's probe list — generic_probes() + SDK readers + MPH file
     probe + optional GUI.
@@ -451,6 +459,8 @@ class ComsolDriver:
         self._client_log_path: Path | None = None
         self._desktop_pid: int | None = None
         self._active_model_tag: str | None = None
+        self._server_owner: str | None = None
+        self._attach_only: bool = False
         self._last_health: dict | None = None
         self._last_disconnect_reason: dict | None = None
         self._launch_options: dict = {}
@@ -668,7 +678,10 @@ class ComsolDriver:
     def _terminate_processes(self) -> None:
         self._kill_pid(self._desktop_pid)
         self._desktop_pid = None
-        for attr in ("_client_proc", "_server_proc"):
+        attrs = ["_client_proc"]
+        if self._server_owner != "external":
+            attrs.append("_server_proc")
+        for attr in attrs:
             proc = getattr(self, attr, None)
             if proc is None:
                 continue
@@ -715,6 +728,8 @@ class ComsolDriver:
             "client_log_path": str(self._client_log_path) if self._client_log_path else None,
             "client_log_tail": self._tail_file(self._client_log_path),
             "desktop_pid": self._desktop_pid,
+            "server_owner": self._server_owner,
+            "attach_only": self._attach_only,
         }
 
     def _lifecycle_error(self, code: str, message: str) -> ComsolLifecycleError:
@@ -842,6 +857,7 @@ class ComsolDriver:
     def _start_desktop_client(
         self,
         bin_dir: str,
+        host: str = "localhost",
         before_pids: set[int] | None = None,
         timeout_s: float = 45,
     ) -> None:
@@ -856,7 +872,7 @@ class ComsolDriver:
             client_exe,
             "mphclient",
             "-host",
-            "localhost",
+            host,
             "-port",
             str(self._port),
         ]
@@ -941,6 +957,58 @@ class ComsolDriver:
         except Exception:
             return []
 
+    def _bind_model(
+        self,
+        ModelUtil,
+        *,
+        preferred_tag: str | None = None,
+        wait_for_tag: bool = False,
+        timeout_s: float = 45,
+        allow_remove_stale: bool = False,
+    ) -> None:
+        model_tag = preferred_tag or "Model1"
+        deadline = time.time() + timeout_s
+        while wait_for_tag and time.time() < deadline:
+            tags = [str(tag) for tag in list(ModelUtil.tags())]
+            if model_tag in tags:
+                break
+            if tags and preferred_tag is None:
+                model_tag = tags[0]
+                break
+            time.sleep(1)
+
+        try:
+            tags = [str(tag) for tag in list(ModelUtil.tags())]
+            if model_tag in tags:
+                self._model = ModelUtil.model(model_tag)
+            elif tags and preferred_tag is None and not allow_remove_stale:
+                model_tag = tags[0]
+                self._model = ModelUtil.model(model_tag)
+            else:
+                try:
+                    self._model = ModelUtil.create(model_tag)
+                except Exception:
+                    if not allow_remove_stale:
+                        raise
+                    for stale in list(ModelUtil.tags()):
+                        try:
+                            ModelUtil.remove(stale)
+                        except Exception:
+                            pass
+                    try:
+                        self._model = ModelUtil.create(model_tag)
+                    except Exception:
+                        model_tag = f"Model_{uuid.uuid4().hex[:6]}"
+                        self._model = ModelUtil.create(model_tag)
+            self._active_model_tag = str(self._model.tag())
+        except Exception as exc:  # noqa: BLE001 - Java exceptions vary by version
+            code = self._classify_comsol_error(str(exc))
+            action = "bind" if not allow_remove_stale else "create"
+            raise self._lifecycle_error(
+                code,
+                f"ModelUtil.{action} failed for tag {model_tag!r}: {exc}",
+            ) from exc
+
     def health(self) -> dict:
         """Best-effort live-session health for `session.summary` / diagnostics."""
         server_returncode = self._server_proc.poll() if self._server_proc is not None else None
@@ -992,6 +1060,8 @@ class ComsolDriver:
             "ui_capabilities": self._ui_capabilities(),
             "port": self._port,
             "server_pid": getattr(self._server_proc, "pid", None),
+            "server_owner": self._server_owner,
+            "attach_only": self._attach_only,
             "server_running": server_running,
             "server_returncode": server_returncode,
             "server_log_path": str(self._server_log_path) if self._server_log_path else None,
@@ -1070,8 +1140,9 @@ class ComsolDriver:
     ) -> dict:
         """Launch comsolmphserver and connect via JPype.
 
-        1. Start `comsolmphserver.exe` as compute backend
-        2. Wait for it to listen on the port
+        1. Start `comsolmphserver.exe` as compute backend, or attach to an
+           externally managed server when `attach_only=true`
+        2. Wait for the target port to listen
         3. Connect via `ModelUtil.connect()` from JPype
         4. If ui_mode resolves to 'server-graphics', keep COMSOL server-side
            graphics enabled so plot windows can appear. If visual_mode resolves
@@ -1083,6 +1154,9 @@ class ComsolDriver:
         workspace = kwargs.pop("workspace", None)
         cwd = kwargs.pop("cwd", None)
         port = kwargs.pop("port", None)
+        attach_only = _as_bool(kwargs.pop("attach_only", False))
+        server_host = kwargs.pop("server_host", kwargs.pop("host", "localhost"))
+        model_tag = kwargs.pop("model_tag", None)
         visual_mode = kwargs.pop("visual_mode", None)
         desktop_timeout = float(kwargs.pop("desktop_timeout", 45))
         requested_ui_mode = ui_mode
@@ -1098,6 +1172,8 @@ class ComsolDriver:
         self._last_disconnect_reason = None
         self._desktop_pid = None
         self._active_model_tag = None
+        self._attach_only = attach_only
+        self._server_owner = "external" if attach_only else "plugin"
 
         root = self._resolve_comsol_root(comsol_root)
         user = user or os.environ.get("COMSOL_USER", "")
@@ -1116,6 +1192,10 @@ class ComsolDriver:
             "requested_visual_mode": visual_mode,
             "visual_mode": normalized_visual_mode,
             "desktop_timeout": desktop_timeout,
+            "attach_only": attach_only,
+            "server_owner": self._server_owner,
+            "server_host": server_host,
+            "model_tag": model_tag,
             "processors": processors,
             "comsol_root": root,
             "workspace": workspace,
@@ -1123,48 +1203,58 @@ class ComsolDriver:
             "port": self._port,
             **kwargs,
         }
-        self._server_log_path, self._server_log_handle = self._open_log("comsol-mphserver")
 
-        if self._check_port(self._port, timeout=0.5):
-            err = self._lifecycle_error(
-                "comsol.server.port_conflict",
-                f"port {self._port} is already accepting connections before launch",
-            )
-            self._close_log_handles()
-            raise err
-
-        # -login auto: use cached credentials set via `comsolmphserver -login force`
-        server_args = [
-            server_exe,
-            "-port", str(self._port),
-            "-multi", "on",
-            "-login", "auto",
-            "-silent",
-        ]
-        if effective_ui_mode == "server-graphics":
-            server_args += ["-graphics", "-3drend", "sw"]
         before_comsol_pids = self._comsol_process_pids()
-        self._server_proc = subprocess.Popen(
-            server_args,
-            stdout=self._server_log_handle,
-            stderr=subprocess.STDOUT,
-        )
+        if attach_only:
+            if not self._check_port(self._port, timeout=2):
+                err = self._lifecycle_error(
+                    "comsol.server.attach_port_closed",
+                    f"attach_only requested but {server_host}:{self._port} is not reachable",
+                )
+                self._close_log_handles()
+                raise err
+        else:
+            self._server_log_path, self._server_log_handle = self._open_log("comsol-mphserver")
 
-        try:
-            port_ready = self._wait_for_port(self._port, timeout=90)
-        except ComsolLifecycleError:
-            self._terminate_processes()
-            self._close_log_handles()
-            raise
+            if self._check_port(self._port, timeout=0.5):
+                err = self._lifecycle_error(
+                    "comsol.server.port_conflict",
+                    f"port {self._port} is already accepting connections before launch",
+                )
+                self._close_log_handles()
+                raise err
 
-        if not port_ready:
-            err = self._lifecycle_error(
-                "comsol.server.port_timeout",
-                f"comsolmphserver did not start listening on port {self._port} within 90s",
+            # -login auto: use cached credentials set via `comsolmphserver -login force`
+            server_args = [
+                server_exe,
+                "-port", str(self._port),
+                "-multi", "on",
+                "-login", "auto",
+                "-silent",
+            ]
+            if effective_ui_mode == "server-graphics":
+                server_args += ["-graphics", "-3drend", "sw"]
+            self._server_proc = subprocess.Popen(
+                server_args,
+                stdout=self._server_log_handle,
+                stderr=subprocess.STDOUT,
             )
-            self._terminate_processes()
-            self._close_log_handles()
-            raise err
+
+            try:
+                port_ready = self._wait_for_port(self._port, timeout=90)
+            except ComsolLifecycleError:
+                self._terminate_processes()
+                self._close_log_handles()
+                raise
+
+            if not port_ready:
+                err = self._lifecycle_error(
+                    "comsol.server.port_timeout",
+                    f"comsolmphserver did not start listening on port {self._port} within 90s",
+                )
+                self._terminate_processes()
+                self._close_log_handles()
+                raise err
 
         # Connect JPype first (lightweight, doesn't grab an exclusive lock)
         # so the GUI client launching next won't race us on "Server is in
@@ -1185,9 +1275,9 @@ class ComsolDriver:
 
         try:
             if user and password:
-                ModelUtil.connect("localhost", self._port, user, password)
+                ModelUtil.connect(server_host, self._port, user, password)
             else:
-                ModelUtil.connect("localhost", self._port)
+                ModelUtil.connect(server_host, self._port)
         except Exception as exc:  # noqa: BLE001 - Java exceptions vary by version
             code = self._classify_comsol_error(str(exc))
             err = self._lifecycle_error(
@@ -1206,6 +1296,7 @@ class ComsolDriver:
             try:
                 self._start_desktop_client(
                     bin_dir,
+                    host=server_host,
                     before_pids=before_comsol_pids,
                     timeout_s=desktop_timeout,
                 )
@@ -1218,63 +1309,47 @@ class ComsolDriver:
                 self._close_log_handles()
                 raise err from exc
 
-            deadline = time.time() + desktop_timeout
-            _model_tag = "Model1"
-            while time.time() < deadline:
-                tags = [str(tag) for tag in list(ModelUtil.tags())]
-                if _model_tag in tags:
-                    break
-                if tags:
-                    _model_tag = tags[0]
-                    break
-                time.sleep(1)
             try:
-                tags = [str(tag) for tag in list(ModelUtil.tags())]
-                if _model_tag in tags:
-                    self._model = ModelUtil.model(_model_tag)
-                else:
-                    self._model = ModelUtil.create(_model_tag)
-                self._active_model_tag = str(self._model.tag())
-            except Exception as exc:  # noqa: BLE001 - Java exceptions vary by version
-                code = self._classify_comsol_error(str(exc))
-                err = self._lifecycle_error(
-                    code,
-                    f"failed to bind shared Desktop model tag {_model_tag!r}: {exc}",
+                self._bind_model(
+                    ModelUtil,
+                    preferred_tag=model_tag,
+                    wait_for_tag=True,
+                    timeout_s=desktop_timeout,
+                    allow_remove_stale=False,
                 )
+            except ComsolLifecycleError as err:
                 self._terminate_processes()
                 self._close_log_handles()
-                raise err from exc
+                raise err
+        elif attach_only:
+            try:
+                self._bind_model(
+                    ModelUtil,
+                    preferred_tag=model_tag,
+                    wait_for_tag=False,
+                    timeout_s=desktop_timeout,
+                    allow_remove_stale=False,
+                )
+            except ComsolLifecycleError as err:
+                self._terminate_processes()
+                self._close_log_handles()
+                raise err
         else:
             # Create model. Guard against the server surviving a previous
             # disconnect(): if "Model1" already exists on the server, that tag
             # belongs to a stale session — remove it first, then create fresh.
             # Fallback: if removal is refused, create with a session-unique name
             # so we never conflict.
-            _model_tag = "Model1"
             try:
-                try:
-                    self._model = ModelUtil.create(_model_tag)
-                except Exception:
-                    for _stale in list(ModelUtil.tags()):
-                        try:
-                            ModelUtil.remove(_stale)
-                        except Exception:
-                            pass
-                    try:
-                        self._model = ModelUtil.create(_model_tag)
-                    except Exception:
-                        _model_tag = f"Model_{uuid.uuid4().hex[:6]}"
-                        self._model = ModelUtil.create(_model_tag)
-                self._active_model_tag = str(self._model.tag())
-            except Exception as exc:  # noqa: BLE001 - Java exceptions vary by version
-                code = self._classify_comsol_error(str(exc))
-                err = self._lifecycle_error(
-                    code,
-                    f"ModelUtil.create failed: {exc}",
+                self._bind_model(
+                    ModelUtil,
+                    preferred_tag=model_tag,
+                    allow_remove_stale=True,
                 )
+            except ComsolLifecycleError as err:
                 self._terminate_processes()
                 self._close_log_handles()
-                raise err from exc
+                raise err
 
         self._ui_mode = effective_ui_mode
         self._connected_at = time.time()
@@ -1304,6 +1379,8 @@ class ComsolDriver:
             "ui_note": ui_note,
             "ui_capabilities": self._ui_capabilities(effective_ui_mode),
             "port": self._port,
+            "server_owner": self._server_owner,
+            "attach_only": self._attach_only,
             "model_tag": str(self._model.tag()),
             "active_model_tag": self._active_model_tag,
             "desktop_pid": self._desktop_pid,
@@ -1495,5 +1572,8 @@ class ComsolDriver:
         self._last_health = reason
         self._session_id = None
         self._connected_at = None
+        self._active_model_tag = None
+        self._server_owner = None
+        self._attach_only = False
         self._run_count = 0
         self._last_run = None

--- a/tests/test_comsol_driver.py
+++ b/tests/test_comsol_driver.py
@@ -169,6 +169,22 @@ class TestLifecycleDiagnostics:
         assert effective == "server-graphics"
         assert "not a live shared Desktop mode yet" in note
 
+    def test_visual_mode_can_request_shared_desktop(self):
+        driver = ComsolDriver()
+
+        effective, note, visual = driver._resolve_visual_mode(
+            ui_mode="gui",
+            visual_mode="shared-desktop",
+        )
+
+        assert effective == "shared-desktop"
+        assert visual == "shared-desktop"
+        assert "active model tag" in note
+        caps = driver._ui_capabilities(effective)
+        assert caps["shared_desktop"] is True
+        assert caps["model_builder_live"] is True
+        assert caps["server_graphics"] is False
+
     def test_wait_for_port_reports_early_server_exit_with_log_tail(self, tmp_path):
         driver = ComsolDriver()
         driver._sim_dir = tmp_path / ".sim"
@@ -235,6 +251,41 @@ class TestLifecycleDiagnostics:
         assert health["windows"] == [
             {"pid": 2468, "role": "server", "title": "Plot 1"}
         ]
+
+    def test_health_reports_shared_desktop_metadata(self, monkeypatch):
+        driver = ComsolDriver()
+        driver._session_id = "s-test"
+        driver._model = object()
+        driver._server_proc = FakeProcess(pid=2468, returncode=None)
+        driver._client_proc = FakeProcess(pid=1357, returncode=0)
+        driver._desktop_pid = 9753
+        driver._active_model_tag = "Model1"
+        driver._port = 65000
+        driver._ui_mode = "shared-desktop"
+        driver._launch_options = {
+            "requested_ui_mode": "gui",
+            "ui_mode": "shared-desktop",
+            "visual_mode": "shared-desktop",
+        }
+        monkeypatch.setattr(driver, "_check_port", lambda *_args, **_kwargs: True)
+        monkeypatch.setattr(
+            driver,
+            "_visible_windows",
+            lambda: [{
+                "pid": 9753,
+                "role": "desktop",
+                "title": "Untitled.mph - COMSOL Multiphysics",
+            }],
+        )
+
+        health = driver.health()
+
+        assert health["connected"] is True
+        assert health["effective_ui_mode"] == "shared-desktop"
+        assert health["ui_capabilities"]["model_builder_live"] is True
+        assert health["desktop_pid"] == 9753
+        assert health["active_model_tag"] == "Model1"
+        assert health["windows"][0]["role"] == "desktop"
 
     def test_query_session_health(self):
         driver = ComsolDriver()

--- a/tests/test_comsol_driver.py
+++ b/tests/test_comsol_driver.py
@@ -287,6 +287,50 @@ class TestLifecycleDiagnostics:
         assert health["active_model_tag"] == "Model1"
         assert health["windows"][0]["role"] == "desktop"
 
+    def test_health_reports_attach_only_external_server(self, monkeypatch):
+        driver = ComsolDriver()
+        driver._session_id = "s-test"
+        driver._model = object()
+        driver._server_proc = None
+        driver._server_owner = "external"
+        driver._attach_only = True
+        driver._active_model_tag = "Model1"
+        driver._port = 65000
+        driver._ui_mode = "headless"
+        driver._launch_options = {
+            "requested_ui_mode": "no_gui",
+            "ui_mode": "headless",
+            "attach_only": True,
+            "server_owner": "external",
+            "server_host": "localhost",
+        }
+        monkeypatch.setattr(driver, "_check_port", lambda *_args, **_kwargs: True)
+
+        health = driver.health()
+
+        assert health["connected"] is True
+        assert health["server_pid"] is None
+        assert health["server_owner"] == "external"
+        assert health["attach_only"] is True
+        assert health["active_model_tag"] == "Model1"
+
+    def test_attach_only_terminate_does_not_kill_external_server(self, monkeypatch):
+        driver = ComsolDriver()
+        server = FakeProcess(pid=2468, returncode=None)
+        client = FakeProcess(pid=1357, returncode=None)
+        killed_pids = []
+        driver._server_proc = server
+        driver._client_proc = client
+        driver._desktop_pid = 9753
+        driver._server_owner = "external"
+        monkeypatch.setattr(driver, "_kill_pid", lambda pid: killed_pids.append(pid))
+
+        driver._terminate_processes()
+
+        assert server.killed is False
+        assert client.killed is True
+        assert killed_pids == [9753]
+
     def test_query_session_health(self):
         driver = ComsolDriver()
 


### PR DESCRIPTION
## Summary
- implements COMSOL `visual_mode=shared-desktop` while keeping sim-cli driver agnostic
- adds `attach_only=true` for externally managed long-lived `comsolmphserver` sessions
- launches `comsol.exe mphclient -host localhost -port <port>` and binds JPype edits to the Desktop active model tag
- reports `model_builder_live`, `desktop_pid`, `active_model_tag`, `server_owner`, and `attach_only` in session health
- updates unit tests and the bundled COMSOL skill docs

## Validation
- `.\.venv\Scripts\python.exe -m pytest --basetemp .pytest_basetemp\attach_only_unit` -> 86 passed, 1 skipped
- Plugin-owned shared desktop smoke on Win1 / COMSOL 6.4:
  `..\sim-cli\.venv\Scripts\python.exe -m sim --json --port 7611 connect --solver comsol --mode solver --ui-mode gui --workspace runs\shared_desktop_driver_smoke --driver-option visual_mode=shared-desktop --driver-option port=2055 --driver-option desktop_timeout=60`
- Plugin-owned health showed `effective_ui_mode=shared-desktop`, `model_builder_live=true`, `desktop_pid=34464`, `active_model_tag=Model1`; `sim exec` changed the visible Desktop model and `sim disconnect` cleaned up server/Desktop
- Attach-only smoke started external `comsolmphserver -port 2056 -multi on -login auto -silent`, then connected with:
  `..\sim-cli\.venv\Scripts\python.exe -m sim --json --port 7612 connect --solver comsol --mode solver --ui-mode gui --workspace runs\attach_only_driver_smoke --driver-option attach_only=true --driver-option visual_mode=shared-desktop --driver-option port=2056 --driver-option desktop_timeout=60`
- Attach-only health showed `server_owner=external`, `attach_only=true`, `server_pid=null`, `desktop_pid=7072`, `active_model_tag=Model1`
- Attach-only `sim exec` changed the visible Desktop model; `sim disconnect` removed the plugin-launched Desktop client but left external `comsolmphserver` listening on 2056, then the smoke manually cleaned that external server