### PR TITLE
ci: publish wheel + manifest to R2 on tag push

### DIFF
--- a/.github/workflows/publish-wheel.yml
+++ b/.github/workflows/publish-wheel.yml
@@ -1,0 +1,84 @@
+name: Publish wheel to R2
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v3
+        with:
+          version: latest
+
+      - name: Build wheel
+        run: uv build --wheel
+
+      - name: Identify wheel
+        id: wheel
+        run: |
+          set -euo pipefail
+          WHEEL=$(ls dist/*.whl | head -n 1)
+          WHEEL_NAME=$(basename "$WHEEL")
+          SHORT=$(echo "$WHEEL_NAME" | sed -E 's/^sim_plugin_([a-z0-9_]+)-([^-]+)-.*/\1/')
+          VERSION=$(echo "$WHEEL_NAME" | sed -E 's/^sim_plugin_([a-z0-9_]+)-([^-]+)-.*/\2/')
+          if [ -z "$SHORT" ] || [ "$SHORT" = "$WHEEL_NAME" ]; then
+            echo "could not parse plugin name from $WHEEL_NAME" >&2
+            exit 1
+          fi
+          {
+            echo "wheel=$WHEEL"
+            echo "wheel_name=$WHEEL_NAME"
+            echo "short=$SHORT"
+            echo "version=$VERSION"
+          } >> "$GITHUB_OUTPUT"
+          echo "→ plugin=$SHORT version=$VERSION"
+
+      - name: Upload wheel + manifest to R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT_URL }}
+          WHEEL: ${{ steps.wheel.outputs.wheel }}
+          WHEEL_NAME: ${{ steps.wheel.outputs.wheel_name }}
+          SHORT: ${{ steps.wheel.outputs.short }}
+          VERSION: ${{ steps.wheel.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          aws s3 cp "$WHEEL" "s3://sim-plugin-wheels/wheels/$WHEEL_NAME" \
+            --endpoint-url "$R2_ENDPOINT" \
+            --content-type application/zip
+
+          aws s3 cp "s3://sim-plugin-wheels/manifest.json" /tmp/manifest.json \
+            --endpoint-url "$R2_ENDPOINT" \
+            || echo '{"updated":"","plugins":{}}' > /tmp/manifest.json
+
+          TODAY=$(date -u +%Y-%m-%d)
+          WHEEL_URL="https://cdn.svdailab.com/wheels/$WHEEL_NAME"
+
+          jq --arg short "$SHORT" --arg version "$VERSION" \
+             --arg wheel "$WHEEL_URL" --arg today "$TODAY" '
+            .updated = $today
+            | .plugins[$short] = {version: $version, wheel: $wheel}
+          ' /tmp/manifest.json > /tmp/manifest.new.json
+
+          aws s3 cp /tmp/manifest.new.json "s3://sim-plugin-wheels/manifest.json" \
+            --endpoint-url "$R2_ENDPOINT" \
+            --content-type application/json
+
+      - name: Verify
+        run: |
+          sleep 3
+          curl -sIo /dev/null -w "wheel HTTP %{http_code}\n" \
+            "https://cdn.svdailab.com/wheels/${{ steps.wheel.outputs.wheel_name }}"
+          echo "manifest entry:"
+          curl -sf "https://cdn.svdailab.com/manifest.json" \
+            | jq '.plugins["${{ steps.wheel.outputs.short }}"]'


### PR DESCRIPTION
Auto-publishes the built wheel to `sim-plugin-wheels` R2 bucket and updates `manifest.json` whenever a `v*` tag is pushed. Required secrets are already set on this repo.