### PR TITLE
[codex] Add COMSOL desktop attach helper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,9 @@ comsol = "sim_plugin_comsol:skills_dir"
 [project.entry-points."sim.plugins"]
 comsol = "sim_plugin_comsol:plugin_info"
 
+[project.scripts]
+sim-comsol-attach = "sim_plugin_comsol.desktop_attach.cli:main"
+
 [project.urls]
 Homepage = "https://github.com/svd-ai-lab/sim-plugin-comsol"
 Issues = "https://github.com/svd-ai-lab/sim-plugin-comsol/issues"

--- a/src/sim_plugin_comsol/_skills/comsol/SKILL.md
+++ b/src/sim_plugin_comsol/_skills/comsol/SKILL.md
@@ -212,7 +212,15 @@ it as a live engineering state, not as a one-shot code generator.
    solved/unsolved state, mesh size), use `inspect_mph(path)` first — no
    JVM and no `sim connect` needed. Skip to step 1 only if the model needs
    to be mutated or solved.
-1. Connect with `sim connect --solver comsol`.
+1. Choose the control path. For interactive Windows work, default to the
+   human-collaboration path unless the task explicitly needs the driver
+   runtime:
+   - Use the standalone Desktop attach helper when the user wants ordinary,
+     realtime-visible COMSOL Desktop work, when they already opened Desktop,
+     or when avoiding the `mphclient` server login dialog matters.
+   - Use `sim connect --solver comsol` only when you need `sim inspect`,
+     JPype session state, driver-managed artifacts, headless/server
+     execution, or compatibility with existing sim runtime workflows.
 2. Run the shared Step-0 version probe and read `session.versions`.
 3. Inspect `sim inspect session.health`.
 4. Inspect the baseline model with `sim inspect comsol.model.describe_text`
@@ -242,12 +250,41 @@ COMSOL has several visual surfaces. Do not collapse them into one
 | `server-graphics` | `comsolmphserver -graphics`; plot windows may appear when a result plot is run. This is the current default effective mode. Legacy `ui_mode=gui` is an alias for this. | Yes for the server-side model, but there is no Model Builder tree. |
 | `desktop-inspection` | Save a `.mph` artifact, then open it in full COMSOL Desktop / Model Builder. | No. It is an inspection copy unless explicitly reloaded. |
 | `shared-desktop` | Full COMSOL Desktop attached to the same server, with the agent binding to the Desktop's active model tag. Request from sim-cli with `--driver-option visual_mode=shared-desktop`. | Yes, when `model_builder_live: true`. |
+| `desktop-attach` | Ordinary COMSOL Desktop, controlled through the Java Shell UIA channel via `sim-comsol-attach`. No `mphclient`, no shared server login dialog. | Yes, in the visible Desktop model, but without `sim inspect`/JPype session introspection. |
 
 Use `sim inspect session.health` or `sim exec` target `session.health`
 to check `requested_ui_mode`, `effective_ui_mode`, `ui_capabilities`,
 PIDs, logs, and visible COMSOL window titles. Treat `model_builder_live:
 false` as authoritative: agent-side JPype edits will not automatically
 refresh a separately opened COMSOL Desktop window.
+
+### Ordinary Desktop attach helper
+
+For interactive Windows work, the normal user-facing default is the
+standalone helper:
+
+```powershell
+sim-comsol-attach open --json --timeout 120
+sim-comsol-attach health --json
+sim-comsol-attach exec --file step.java --json
+```
+
+`open` launches normal `comsol.exe` if no suitable Desktop exists,
+clicks Blank Model when needed, opens Java Shell, and waits for a
+`SyntaxEditor` input. It does not launch `comsol.exe mphclient`, so it
+avoids the repeated "Connect to COMSOL Multiphysics Server" dialog.
+
+For `exec`, submit bounded Java Shell snippets that use COMSOL's Java API
+against the visible Desktop model. Keep the same modeling discipline as
+`sim exec`: one layer at a time, verify the Desktop after each geometry,
+material, physics, mesh, solve, and plot step, then continue. The helper
+audits submissions under `.sim/comsol-desktop-attach/audit.jsonl`.
+
+By default, `exec` rejects arbitrary Java lines that do not start from the
+COMSOL model surface. Use `--allow-arbitrary-java` only for deliberate
+diagnostic snippets. If you need structured model introspection, saved
+artifacts, or cross-session runtime state, switch back to the driver path
+with `sim connect --solver comsol`.
 
 Shared-desktop gotcha verified on Win1 with COMSOL 6.4: launching
 `comsol.exe mphclient -host localhost -port <port>` does attach a full

--- a/src/sim_plugin_comsol/desktop_attach/__init__.py
+++ b/src/sim_plugin_comsol/desktop_attach/__init__.py
@@ -1,0 +1,26 @@
+"""Attach to a user-owned COMSOL Desktop through Java Shell.
+
+This package is intentionally separate from :class:`ComsolDriver`.
+It provides a small Desktop-control primitive for the copilot workflow
+where the user already has COMSOL Desktop open and wants an agent to
+submit Java API commands into that same visible session.
+"""
+from __future__ import annotations
+
+from .health import health
+from .open import open_desktop
+from .shell import find_java_shell, find_java_shell_in_snapshot
+from .submit import submit_code
+from .target import DesktopSelector, DesktopTarget, find_desktops, resolve_target
+
+__all__ = [
+    "DesktopSelector",
+    "DesktopTarget",
+    "find_desktops",
+    "find_java_shell",
+    "find_java_shell_in_snapshot",
+    "health",
+    "open_desktop",
+    "resolve_target",
+    "submit_code",
+]

--- a/src/sim_plugin_comsol/desktop_attach/__main__.py
+++ b/src/sim_plugin_comsol/desktop_attach/__main__.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from .cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sim_plugin_comsol/desktop_attach/audit.py
+++ b/src/sim_plugin_comsol/desktop_attach/audit.py
@@ -1,0 +1,52 @@
+"""Audit logging for Java Shell submissions."""
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .shell import JavaShellChannel
+
+
+def default_audit_dir(cwd: str | Path | None = None) -> Path:
+    base = Path(cwd) if cwd is not None else Path.cwd()
+    return base / ".sim" / "comsol-desktop-attach"
+
+
+def code_hash(code: str) -> str:
+    return hashlib.sha256(code.encode("utf-8")).hexdigest()
+
+
+def capped_preview(code: str, limit: int = 200) -> str:
+    compact = code.replace("\r\n", "\n").strip()
+    if len(compact) <= limit:
+        return compact
+    return compact[:limit] + "..."
+
+
+def append_audit(
+    channel: JavaShellChannel,
+    code: str,
+    status: str,
+    *,
+    audit_dir: str | Path | None = None,
+) -> Path:
+    out_dir = Path(audit_dir) if audit_dir is not None else default_audit_dir()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    path = out_dir / "audit.jsonl"
+    target = channel.target
+    record = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "desktop_pid": target.desktop_pid,
+        "hwnd": target.hwnd,
+        "window_title": target.window_title,
+        "target_id": target.target_id,
+        "exec_language": "java-shell",
+        "code_sha256": code_hash(code),
+        "code_preview": capped_preview(code),
+        "status": status,
+    }
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, ensure_ascii=True) + "\n")
+    return path

--- a/src/sim_plugin_comsol/desktop_attach/cli.py
+++ b/src/sim_plugin_comsol/desktop_attach/cli.py
@@ -1,0 +1,113 @@
+"""CLI for the COMSOL Desktop attach primitive."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .health import health
+from .open import OpenDesktopError, open_desktop
+from .shell import find_java_shell
+from .submit import SubmitError, submit_code
+from .target import DesktopSelector, TargetResolutionError, resolve_target
+
+
+def _selector(args: argparse.Namespace) -> DesktopSelector:
+    return DesktopSelector(
+        desktop_pid=args.desktop_pid,
+        hwnd=args.hwnd,
+        window_title=args.window_title,
+    )
+
+
+def _print(payload: dict) -> int:
+    print(json.dumps(payload, indent=2, ensure_ascii=True))
+    return 0 if payload.get("ok") else 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="comsol-desktop-attach")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    def add_target_options(p: argparse.ArgumentParser) -> None:
+        p.add_argument("--desktop-pid", type=int, default=None)
+        p.add_argument("--hwnd", type=int, default=None)
+        p.add_argument("--window-title", default=None)
+        p.add_argument("--json", action="store_true", help="Accepted for compatibility; output is always JSON.")
+
+    add_target_options(sub.add_parser("health"))
+    add_target_options(sub.add_parser("snapshot"))
+
+    open_p = sub.add_parser("open")
+    add_target_options(open_p)
+    open_p.add_argument("--comsol-root", default=None)
+    open_p.add_argument("--file", type=Path, default=None)
+    open_p.add_argument("--timeout", type=float, default=90)
+    open_p.add_argument("--no-blank-model", action="store_true")
+    open_p.add_argument("--no-java-shell", action="store_true")
+
+    exec_p = sub.add_parser("exec")
+    add_target_options(exec_p)
+    group = exec_p.add_mutually_exclusive_group(required=True)
+    group.add_argument("--code")
+    group.add_argument("--file", type=Path)
+    exec_p.add_argument("--allow-arbitrary-java", action="store_true")
+    exec_p.add_argument("--submit-key", default="run_button")
+    exec_p.add_argument("--audit-dir", type=Path, default=None)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    selector = _selector(args)
+    if args.command == "health":
+        return _print(health(selector))
+    if args.command == "open":
+        try:
+            return _print(
+                open_desktop(
+                    comsol_root=args.comsol_root,
+                    model_file=str(args.file) if args.file else None,
+                    selector=selector,
+                    timeout_s=args.timeout,
+                    create_blank_model=not args.no_blank_model,
+                    open_java_shell=not args.no_java_shell,
+                ).to_dict()
+            )
+        except OpenDesktopError as exc:
+            return _print(exc.to_dict())
+        except Exception as exc:  # noqa: BLE001
+            return _print({"ok": False, "status": "open_failed", "error": str(exc)})
+    if args.command == "snapshot":
+        try:
+            target = resolve_target(selector)
+            from sim.gui import _pywinauto_tools  # type: ignore
+            snapshot = _pywinauto_tools.snapshot_uia_tree((), max_depth=8)
+            return _print({"ok": bool(snapshot.get("ok")), "target": target.to_dict(), "snapshot": snapshot})
+        except TargetResolutionError as exc:
+            return _print(exc.to_dict())
+        except Exception as exc:  # noqa: BLE001
+            return _print({"ok": False, "status": "snapshot_failed", "error": str(exc)})
+    if args.command == "exec":
+        try:
+            target = resolve_target(selector)
+            channel = find_java_shell(target)
+            code = args.code if args.code is not None else args.file.read_text(encoding="utf-8")
+            return _print(
+                submit_code(
+                    channel,
+                    code,
+                    allow_arbitrary_java=args.allow_arbitrary_java,
+                    submit_key=args.submit_key,
+                    audit_dir=args.audit_dir,
+                )
+            )
+        except (TargetResolutionError, SubmitError) as exc:
+            return _print(exc.to_dict())
+        except Exception as exc:  # noqa: BLE001
+            return _print({"ok": False, "status": "exec_failed", "error": str(exc)})
+    return _print({"ok": False, "status": "unknown_command", "error": args.command})
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sim_plugin_comsol/desktop_attach/health.py
+++ b/src/sim_plugin_comsol/desktop_attach/health.py
@@ -1,0 +1,38 @@
+"""Health composition for COMSOL Desktop attach."""
+from __future__ import annotations
+
+from .shell import JavaShellError, find_java_shell
+from .target import DesktopSelector, TargetResolutionError, resolve_target
+
+
+def health(selector: DesktopSelector | None = None) -> dict:
+    """Return target/channel/session health for a Desktop attach target."""
+
+    try:
+        target = resolve_target(selector)
+    except TargetResolutionError as exc:
+        return {
+            **exc.to_dict(),
+            "target_alive": False,
+            "channel_alive": False,
+            "session_alive": False,
+        }
+    try:
+        channel = find_java_shell(target)
+    except JavaShellError as exc:
+        return {
+            **exc.to_dict(),
+            "target": target.to_dict(),
+            "target_alive": True,
+            "channel_alive": False,
+            "session_alive": False,
+        }
+    return {
+        "ok": True,
+        "status": "ready",
+        "target": target.to_dict(),
+        "channel": channel.to_dict(),
+        "target_alive": True,
+        "channel_alive": True,
+        "session_alive": True,
+    }

--- a/src/sim_plugin_comsol/desktop_attach/open.py
+++ b/src/sim_plugin_comsol/desktop_attach/open.py
@@ -1,0 +1,177 @@
+"""Open ordinary COMSOL Desktop and prepare Java Shell attach."""
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from .shell import find_java_shell
+from .target import DesktopSelector, DesktopTarget, TargetResolutionError, resolve_target
+
+
+class OpenDesktopError(RuntimeError):
+    def __init__(self, code: str, message: str, details: dict | None = None):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.details = details or {}
+
+    def to_dict(self) -> dict:
+        return {"ok": False, "status": self.code, "error": self.message, **self.details}
+
+
+@dataclass(frozen=True)
+class OpenResult:
+    target: DesktopTarget
+    reused_existing: bool
+    launched_pid: int | None
+    java_shell_ready: bool
+    channel: dict | None = None
+
+    def to_dict(self) -> dict:
+        return {
+            "ok": True,
+            "status": "ready" if self.java_shell_ready else "desktop_open",
+            "reused_existing": self.reused_existing,
+            "launched_pid": self.launched_pid,
+            "target": self.target.to_dict(),
+            "channel": self.channel,
+        }
+
+
+def _comsol_exe(comsol_root: str | None = None) -> Path:
+    if comsol_root:
+        root = Path(comsol_root)
+    else:
+        from sim_plugin_comsol.driver import _scan_comsol_installs
+
+        installs = _scan_comsol_installs()
+        if not installs:
+            raise OpenDesktopError(
+                "comsol_not_found",
+                "No COMSOL installation was detected. Set COMSOL_ROOT or install COMSOL.",
+            )
+        root = Path(installs[0].path)
+    if os.name == "nt":
+        exe = root / "bin" / "win64" / "comsol.exe"
+    else:
+        exe = root / "bin" / "comsol"
+    if not exe.is_file():
+        raise OpenDesktopError("comsol_not_found", f"COMSOL launcher not found at {exe}")
+    return exe
+
+
+def _launch_desktop(comsol_root: str | None = None, model_file: str | None = None) -> subprocess.Popen:
+    exe = _comsol_exe(comsol_root)
+    args = [str(exe)]
+    if model_file:
+        args.append(str(Path(model_file)))
+    return subprocess.Popen(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def _click_best_effort(labels: tuple[str, ...], timeout_s: float = 12) -> dict:
+    if os.name != "nt":
+        return {"clicked": False, "error": "UIA click requires Windows"}
+    try:
+        from pywinauto import Desktop
+    except Exception as exc:  # noqa: BLE001
+        return {"clicked": False, "error": f"pywinauto import failed: {exc}"}
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        for window in Desktop(backend="uia").windows():
+            try:
+                for control in window.descendants():
+                    name = control.window_text() or ""
+                    if name not in labels:
+                        continue
+                    control.click_input()
+                    return {"clicked": True, "label": name, "window": window.window_text() or ""}
+            except Exception:
+                continue
+        time.sleep(0.5)
+    return {"clicked": False, "error": f"none of {labels!r} found"}
+
+
+def _prepare_blank_model_if_needed(timeout_s: float = 20) -> dict:
+    """Best-effort pass through Model Wizard / Blank Model startup screens."""
+
+    # English and Chinese labels we have seen or expect from COMSOL startup.
+    blank = _click_best_effort(("Blank Model", "空白模型"), timeout_s=timeout_s)
+    if not blank.get("clicked"):
+        return {"blank_model": blank, "done": False}
+    time.sleep(1)
+    done = _click_best_effort(("Done", "完成"), timeout_s=8)
+    return {"blank_model": blank, "done": done}
+
+
+def _open_java_shell_button(timeout_s: float = 8) -> dict:
+    # The Developer ribbon exposes this as a BarToggleButton in COMSOL 6.4.
+    return _click_best_effort(("Java Shell",), timeout_s=timeout_s)
+
+
+def open_desktop(
+    *,
+    comsol_root: str | None = None,
+    model_file: str | None = None,
+    selector: DesktopSelector | None = None,
+    timeout_s: float = 90,
+    create_blank_model: bool = True,
+    open_java_shell: bool = True,
+) -> OpenResult:
+    """Open ordinary COMSOL Desktop and return an attach-ready target."""
+
+    selector = selector or DesktopSelector()
+    try:
+        target = resolve_target(selector)
+        reused_existing = True
+        launched_pid = None
+    except TargetResolutionError:
+        proc = _launch_desktop(comsol_root=comsol_root, model_file=model_file)
+        reused_existing = False
+        launched_pid = proc.pid
+        deadline = time.time() + timeout_s
+        last_error: TargetResolutionError | None = None
+        target = None
+        while time.time() < deadline:
+            try:
+                target = resolve_target(selector)
+                break
+            except TargetResolutionError as exc:
+                last_error = exc
+                time.sleep(1)
+        if target is None:
+            raise OpenDesktopError(
+                "desktop_timeout",
+                f"COMSOL Desktop did not become visible within {timeout_s}s.",
+                {"last_error": last_error.to_dict() if last_error else None, "launched_pid": launched_pid},
+            )
+
+    wizard = _prepare_blank_model_if_needed() if create_blank_model and not model_file else None
+    shell_button = _open_java_shell_button() if open_java_shell else None
+    try:
+        channel = find_java_shell(target)
+        return OpenResult(
+            target=target,
+            reused_existing=reused_existing,
+            launched_pid=launched_pid,
+            java_shell_ready=True,
+            channel={
+                **channel.to_dict(),
+                "wizard": wizard,
+                "open_java_shell_button": shell_button,
+            },
+        )
+    except Exception as exc:  # noqa: BLE001
+        return OpenResult(
+            target=target,
+            reused_existing=reused_existing,
+            launched_pid=launched_pid,
+            java_shell_ready=False,
+            channel={
+                "error": str(exc),
+                "wizard": wizard,
+                "open_java_shell_button": shell_button,
+            },
+        )

--- a/src/sim_plugin_comsol/desktop_attach/shell.py
+++ b/src/sim_plugin_comsol/desktop_attach/shell.py
@@ -1,0 +1,304 @@
+"""Locate COMSOL Java Shell in a UIA snapshot."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from typing import Iterable
+
+from .target import DesktopTarget
+
+
+class JavaShellError(RuntimeError):
+    """Raised when the Java Shell channel cannot be located."""
+
+    def __init__(self, code: str, message: str, artifacts: dict | None = None):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.artifacts = artifacts or {}
+
+    def to_dict(self) -> dict:
+        return {
+            "ok": False,
+            "status": self.code,
+            "error": self.message,
+            "artifacts": self.artifacts,
+        }
+
+
+@dataclass(frozen=True)
+class JavaShellChannel:
+    target: DesktopTarget
+    pane_handle: int | None
+    input_handle: int | None
+    input_control_type: str
+    input_class_name: str = ""
+    input_rect: list[int] | None = None
+
+    def to_dict(self) -> dict:
+        return {
+            "target": self.target.to_dict(),
+            "pane_handle": self.pane_handle,
+            "input_handle": self.input_handle,
+            "input_control_type": self.input_control_type,
+            "input_class_name": self.input_class_name,
+            "input_rect": self.input_rect,
+            "exec_language": "java-shell",
+        }
+
+
+def _iter_nodes(node: dict) -> Iterable[dict]:
+    yield node
+    for child in (node.get("children") or node.get("controls") or []):
+        yield from _iter_nodes(child)
+
+
+def _node_name(node: dict) -> str:
+    return str(node.get("name") or "")
+
+
+def _control_type(node: dict) -> str:
+    return str(node.get("control_type") or "")
+
+
+def _class_name(node: dict) -> str:
+    return str(node.get("class_name") or "")
+
+
+def _node_handle(node: dict) -> int | None:
+    raw = node.get("handle")
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return None
+    return value or None
+
+
+def _is_java_shell_node(node: dict) -> bool:
+    name = _node_name(node).lower()
+    return "java shell" in name or ("java" in name and "shell" in name)
+
+
+def _is_editable(node: dict) -> bool:
+    return _control_type(node).lower() in {"edit", "document"}
+
+
+def _editable_rank(node: dict) -> tuple[int, int]:
+    """Prefer the actual Java Shell input editor over output documents."""
+
+    ctype = _control_type(node).lower()
+    class_name = _class_name(node).lower()
+    name = _node_name(node).lower()
+    if class_name == "syntaxeditor":
+        return (0, 0)
+    if "input" in name or "command" in name:
+        return (1, 0)
+    if ctype == "edit":
+        return (2, 0)
+    if ctype == "document":
+        return (3, 0)
+    return (9, 0)
+
+
+def find_java_shell_in_snapshot(
+    snapshot: dict,
+    target: DesktopTarget,
+) -> JavaShellChannel:
+    """Find Java Shell pane and input control from a UIA snapshot dict."""
+
+    windows = snapshot.get("windows") or []
+    target_window = None
+    for window in windows:
+        if int(window.get("hwnd") or 0) == target.hwnd:
+            target_window = window
+            break
+    if target_window is None:
+        raise JavaShellError(
+            "target_not_found",
+            f"Resolved target hwnd={target.hwnd} was not present in the UIA snapshot.",
+        )
+
+    panes = [node for node in _iter_nodes(target_window) if _is_java_shell_node(node)]
+    if not panes:
+        raise JavaShellError(
+            "shell_not_visible",
+            "Java Shell was not found. Open COMSOL Desktop > Home > Windows > Java Shell, then retry.",
+        )
+
+    # Prefer the deepest/last matching node; docked panes often have a parent
+    # group and a named child, and the child's descendants are more precise.
+    pane = panes[-1]
+    edits = [node for node in _iter_nodes(pane) if _is_editable(node)]
+    if not edits:
+        raise JavaShellError(
+            "input_not_found",
+            "Java Shell was found, but no Edit/Document input control was found inside it.",
+        )
+    edit = sorted(enumerate(edits), key=lambda pair: (_editable_rank(pair[1]), -pair[0]))[0][1]
+    return JavaShellChannel(
+        target=target,
+        pane_handle=_node_handle(pane),
+        input_handle=_node_handle(edit),
+        input_control_type=_control_type(edit),
+        input_class_name=_class_name(edit),
+        input_rect=edit.get("rect"),
+    )
+
+
+def _snapshot_for_target(target: DesktopTarget, max_depth: int = 8) -> dict:
+    try:
+        from sim.gui import _pywinauto_tools  # type: ignore
+    except Exception as exc:  # noqa: BLE001
+        raise JavaShellError(
+            "uia_unavailable",
+            f"sim.gui UIA helpers are unavailable: {exc}",
+        ) from exc
+    result = _pywinauto_tools.snapshot_uia_tree((), max_depth=max_depth)
+    if not result.get("ok"):
+        raise JavaShellError(
+            "snapshot_failed",
+            str(result.get("error") or "failed to snapshot UIA tree"),
+        )
+    return result
+
+
+def _find_java_shell_live(
+    target: DesktopTarget,
+    timeout_s: float = 15,
+    *,
+    try_open: bool = True,
+) -> JavaShellChannel:
+    if os.name != "nt":
+        raise JavaShellError("uia_unavailable", "COMSOL Desktop attach requires Windows.")
+    script = textwrap.dedent(
+        """
+        import json
+        import sys
+        PARAMS = json.loads(sys.argv[1])
+
+        def emit(payload):
+            print(json.dumps(payload, ensure_ascii=True))
+
+        try:
+            from pywinauto import Application
+        except Exception as exc:
+            emit({"ok": False, "status": "uia_unavailable", "error": f"pywinauto import failed: {exc}"})
+            raise SystemExit(0)
+
+        def scan(win):
+            shell_panes = []
+            syntax_editors = []
+            edits = []
+            for control in win.descendants():
+                try:
+                    name = control.window_text() or ""
+                    ctype = control.element_info.control_type or ""
+                    class_name = getattr(control.element_info, "class_name", "") or ""
+                    rect_obj = control.rectangle()
+                    rect = [rect_obj.left, rect_obj.top, rect_obj.right, rect_obj.bottom]
+                except Exception:
+                    continue
+                lowered = name.lower()
+                if "java" in lowered and "shell" in lowered:
+                    shell_panes.append({"handle": getattr(control, "handle", 0) or 0, "rect": rect, "control_type": ctype, "class_name": class_name})
+                if ctype == "Edit" and class_name == "SyntaxEditor":
+                    syntax_editors.append({"handle": getattr(control, "handle", 0) or 0, "rect": rect, "control_type": ctype, "class_name": class_name})
+                elif ctype == "Edit" and ("input" in lowered or "command" in lowered):
+                    edits.append({"handle": getattr(control, "handle", 0) or 0, "rect": rect, "control_type": ctype, "class_name": class_name})
+            candidates = syntax_editors or edits
+            return shell_panes, candidates
+
+        def click_java_shell_button(win):
+            for control in win.descendants():
+                try:
+                    name = control.window_text() or ""
+                    ctype = control.element_info.control_type or ""
+                    class_name = getattr(control.element_info, "class_name", "") or ""
+                except Exception:
+                    continue
+                if name == "Java Shell" and ctype == "Button":
+                    try:
+                        control.click_input()
+                        return {"clicked": True, "class_name": class_name}
+                    except Exception as exc:
+                        return {"clicked": False, "error": str(exc), "class_name": class_name}
+            return {"clicked": False, "error": "Java Shell button not found"}
+
+        try:
+            import time
+            app = Application(backend="uia").connect(handle=int(PARAMS["hwnd"]))
+            win = app.window(handle=int(PARAMS["hwnd"]))
+            shell_panes, candidates = scan(win)
+            opened = None
+            if not candidates and PARAMS.get("try_open"):
+                opened = click_java_shell_button(win)
+                if opened.get("clicked"):
+                    time.sleep(0.8)
+                    shell_panes, candidates = scan(win)
+            if not shell_panes and not candidates:
+                emit({"ok": False, "status": "shell_not_visible", "error": "Java Shell was not found. Open COMSOL Desktop > Home > Windows > Java Shell, then retry.", "open_attempt": opened})
+                raise SystemExit(0)
+            if not candidates:
+                emit({"ok": False, "status": "input_not_found", "error": "Java Shell was found, but no SyntaxEditor/Edit input control was found.", "open_attempt": opened})
+                raise SystemExit(0)
+            if not shell_panes:
+                shell_panes = [{"handle": 0, "rect": None, "control_type": "", "class_name": ""}]
+            emit({"ok": True, "pane": shell_panes[-1], "input": candidates[-1]})
+        except Exception as exc:
+            emit({"ok": False, "status": "snapshot_failed", "error": str(exc)})
+        """
+    ).strip()
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", script, json.dumps({"hwnd": target.hwnd, "try_open": try_open})],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout_s,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise JavaShellError("snapshot_failed", f"live Java Shell scan timed out after {timeout_s}s") from exc
+    lines = [line for line in (proc.stdout or "").splitlines() if line.strip()]
+    if proc.returncode != 0 and not lines:
+        raise JavaShellError("snapshot_failed", (proc.stderr or "").strip() or f"live scan exited {proc.returncode}")
+    if not lines:
+        raise JavaShellError("snapshot_failed", "live Java Shell scan emitted no JSON")
+    try:
+        payload = json.loads(lines[-1])
+    except json.JSONDecodeError as exc:
+        raise JavaShellError("snapshot_failed", f"live scan emitted invalid JSON: {lines[-1]!r}") from exc
+    if not payload.get("ok"):
+        raise JavaShellError(str(payload.get("status") or "input_not_found"), str(payload.get("error") or "Java Shell input not found"))
+    pane = payload["pane"]
+    edit = payload["input"]
+    return JavaShellChannel(
+        target=target,
+        pane_handle=int(pane.get("handle") or 0) or None,
+        input_handle=int(edit.get("handle") or 0) or None,
+        input_control_type=str(edit.get("control_type") or ""),
+        input_class_name=str(edit.get("class_name") or ""),
+        input_rect=edit.get("rect"),
+    )
+
+
+def find_java_shell(
+    target: DesktopTarget,
+    *,
+    snapshot: dict | None = None,
+    max_depth: int = 8,
+) -> JavaShellChannel:
+    """Locate a Java Shell channel for a resolved COMSOL Desktop target."""
+
+    if snapshot is not None:
+        return find_java_shell_in_snapshot(snapshot, target)
+    try:
+        return find_java_shell_in_snapshot(_snapshot_for_target(target, max_depth), target)
+    except JavaShellError as exc:
+        if exc.code not in {"input_not_found", "shell_not_visible"}:
+            raise
+        return _find_java_shell_live(target)

--- a/src/sim_plugin_comsol/desktop_attach/submit.py
+++ b/src/sim_plugin_comsol/desktop_attach/submit.py
@@ -1,0 +1,264 @@
+"""Submit Java Shell code to a resolved COMSOL Desktop target."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+
+from .audit import append_audit
+from .shell import JavaShellChannel
+
+
+class SubmitError(RuntimeError):
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+    def to_dict(self) -> dict:
+        return {"ok": False, "status": self.code, "error": self.message}
+
+
+def validate_guardrail(code: str, *, allow_arbitrary_java: bool = False) -> None:
+    """Apply the MVP Java Shell guardrail."""
+
+    if allow_arbitrary_java:
+        return
+    for lineno, line in enumerate(code.splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("//") or stripped.startswith("#"):
+            continue
+        if stripped.startswith("model."):
+            continue
+        raise SubmitError(
+            "guardrail_rejected",
+            f"Line {lineno} is outside the MVP allowlist; use allow_arbitrary_java to submit it.",
+        )
+
+
+def _run_submit_subprocess(
+    channel: JavaShellChannel,
+    code_path: Path,
+    *,
+    submit_key: str = "run_button",
+    timeout_s: float = 15,
+) -> dict:
+    if os.name != "nt":
+        return {"ok": False, "status": "uia_unavailable", "error": "Desktop attach requires Windows"}
+
+    params = {
+        "hwnd": channel.target.hwnd,
+        "input_handle": channel.input_handle,
+        "code_path": str(code_path),
+        "submit_key": submit_key,
+    }
+    script = textwrap.dedent(
+        """
+        import ctypes
+        import json
+        import sys
+        import time
+        from pathlib import Path
+
+        PARAMS = json.loads(sys.argv[1])
+
+        def emit(payload):
+            print(json.dumps(payload, ensure_ascii=True))
+
+        try:
+            from pywinauto import Application, mouse
+            from pywinauto.keyboard import send_keys
+        except Exception as exc:
+            emit({"ok": False, "status": "uia_unavailable", "error": f"pywinauto import failed: {exc}"})
+            raise SystemExit(0)
+
+        CF_UNICODETEXT = 13
+        GMEM_MOVEABLE = 0x0002
+        user32 = ctypes.windll.user32
+        kernel32 = ctypes.windll.kernel32
+        user32.GetClipboardData.restype = ctypes.c_void_p
+        kernel32.GlobalLock.argtypes = [ctypes.c_void_p]
+        kernel32.GlobalLock.restype = ctypes.c_void_p
+        kernel32.GlobalUnlock.argtypes = [ctypes.c_void_p]
+        kernel32.GlobalAlloc.argtypes = [ctypes.c_uint, ctypes.c_size_t]
+        kernel32.GlobalAlloc.restype = ctypes.c_void_p
+        user32.SetClipboardData.argtypes = [ctypes.c_uint, ctypes.c_void_p]
+        ctypes.memmove.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t]
+
+        def get_clipboard_text():
+            if not user32.OpenClipboard(None):
+                return None
+            try:
+                handle = user32.GetClipboardData(CF_UNICODETEXT)
+                if not handle:
+                    return ""
+                ptr = kernel32.GlobalLock(handle)
+                if not ptr:
+                    return ""
+                try:
+                    return ctypes.wstring_at(ptr)
+                finally:
+                    kernel32.GlobalUnlock(handle)
+            finally:
+                user32.CloseClipboard()
+
+        def set_clipboard_text(text):
+            data = text.encode("utf-16-le") + b"\\x00\\x00"
+            buf = ctypes.create_string_buffer(data)
+            if not user32.OpenClipboard(None):
+                raise RuntimeError("OpenClipboard failed")
+            try:
+                user32.EmptyClipboard()
+                handle = kernel32.GlobalAlloc(GMEM_MOVEABLE, len(data))
+                if not handle:
+                    raise RuntimeError("GlobalAlloc failed")
+                ptr = kernel32.GlobalLock(handle)
+                if not ptr:
+                    raise RuntimeError("GlobalLock failed")
+                try:
+                    ctypes.memmove(ptr, ctypes.addressof(buf), len(data))
+                finally:
+                    kernel32.GlobalUnlock(handle)
+                if not user32.SetClipboardData(CF_UNICODETEXT, handle):
+                    raise RuntimeError("SetClipboardData failed")
+            finally:
+                user32.CloseClipboard()
+
+        def find_shell_input(win):
+            syntax_editors = []
+            edit_controls = []
+            try:
+                descendants = win.descendants()
+            except Exception:
+                descendants = []
+            for control in descendants:
+                try:
+                    ctype = control.element_info.control_type or ""
+                    class_name = getattr(control.element_info, "class_name", "") or ""
+                    name = control.window_text() or ""
+                except Exception:
+                    continue
+                if ctype == "Edit" and class_name == "SyntaxEditor":
+                    syntax_editors.append(control)
+                elif ctype == "Edit" and ("input" in name.lower() or "command" in name.lower()):
+                    edit_controls.append(control)
+                elif ctype == "Edit":
+                    edit_controls.append(control)
+            if syntax_editors:
+                return syntax_editors[-1]
+            if edit_controls:
+                return edit_controls[-1]
+            return None
+
+        try:
+            code = Path(PARAMS["code_path"]).read_text(encoding="utf-8")
+            app = Application(backend="uia").connect(handle=int(PARAMS["hwnd"]))
+            win = app.window(handle=int(PARAMS["hwnd"]))
+            win.set_focus()
+            target = find_shell_input(win)
+            if target is None:
+                emit({"ok": False, "status": "input_not_found", "error": "No Java Shell SyntaxEditor/Edit input was found."})
+                raise SystemExit(0)
+            try:
+                target.click_input()
+            except Exception:
+                try:
+                    target.set_focus()
+                except Exception:
+                    pass
+            old_clipboard = get_clipboard_text()
+            set_clipboard_text(code)
+            send_keys("^a")
+            send_keys("^v")
+            key = PARAMS.get("submit_key") or "ctrl_enter"
+            if key in {"run_button", "button"}:
+                rect = target.rectangle()
+                x = max(rect.left - 14, 0)
+                y = rect.top + max(int(rect.height() / 2), 1)
+                mouse.click(button="left", coords=(x, y))
+            elif key in {"ctrl_enter", "ctrl+enter"}:
+                send_keys("^{ENTER}")
+            elif key == "enter":
+                send_keys("{ENTER}")
+            else:
+                emit({"ok": False, "status": "submit_failed", "error": f"unknown submit_key={key!r}"})
+                raise SystemExit(0)
+            time.sleep(0.2)
+            if old_clipboard is not None:
+                try:
+                    set_clipboard_text(old_clipboard)
+                except Exception:
+                    pass
+            emit({"ok": True, "status": "submitted", "verification": "verification_unavailable"})
+        except Exception as exc:
+            emit({"ok": False, "status": "submit_failed", "error": str(exc)})
+        """
+    ).strip()
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", script, json.dumps(params)],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout_s,
+        )
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "status": "submit_failed", "error": f"submit timed out after {timeout_s}s"}
+    if proc.returncode != 0:
+        return {
+            "ok": False,
+            "status": "submit_failed",
+            "error": (proc.stderr or "").strip() or f"submit subprocess exited {proc.returncode}",
+        }
+    lines = [line for line in (proc.stdout or "").splitlines() if line.strip()]
+    if not lines:
+        return {"ok": False, "status": "submit_failed", "error": "submit subprocess emitted no JSON"}
+    try:
+        return json.loads(lines[-1])
+    except json.JSONDecodeError:
+        return {"ok": False, "status": "submit_failed", "error": f"invalid submit JSON: {lines[-1]!r}"}
+
+
+def submit_code(
+    channel: JavaShellChannel,
+    code: str,
+    *,
+    allow_arbitrary_java: bool = False,
+    submit_key: str = "run_button",
+    audit_dir: str | Path | None = None,
+    timeout_s: float = 15,
+) -> dict:
+    """Submit Java Shell code through UIA and append an audit record."""
+
+    validate_guardrail(code, allow_arbitrary_java=allow_arbitrary_java)
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", suffix=".java", delete=False) as fh:
+        fh.write(code)
+        code_path = Path(fh.name)
+    try:
+        result = _run_submit_subprocess(
+            channel,
+            code_path,
+            submit_key=submit_key,
+            timeout_s=timeout_s,
+        )
+    finally:
+        try:
+            code_path.unlink()
+        except OSError:
+            pass
+
+    audit_path = append_audit(
+        channel,
+        code,
+        str(result.get("status") or ("submitted" if result.get("ok") else "submit_failed")),
+        audit_dir=audit_dir,
+    )
+    result["audit_log"] = str(audit_path)
+    result["exec_language"] = "java-shell"
+    result["target"] = channel.target.to_dict()
+    return result

--- a/src/sim_plugin_comsol/desktop_attach/target.py
+++ b/src/sim_plugin_comsol/desktop_attach/target.py
@@ -1,0 +1,151 @@
+"""COMSOL Desktop target discovery and disambiguation."""
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Callable, Iterable
+
+
+class TargetResolutionError(RuntimeError):
+    """Raised when a Desktop target cannot be resolved unambiguously."""
+
+    def __init__(self, code: str, message: str, candidates: list[dict] | None = None):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.candidates = candidates or []
+
+    def to_dict(self) -> dict:
+        return {
+            "ok": False,
+            "status": self.code,
+            "error": self.message,
+            "candidates": self.candidates,
+        }
+
+
+@dataclass(frozen=True)
+class DesktopSelector:
+    """Selector for a user-owned COMSOL Desktop window."""
+
+    desktop_pid: int | None = None
+    hwnd: int | None = None
+    window_title: str | None = None
+    exclude_pids: frozenset[int] = field(default_factory=frozenset)
+
+
+@dataclass(frozen=True)
+class DesktopTarget:
+    """Resolved COMSOL Desktop target metadata."""
+
+    desktop_pid: int
+    hwnd: int
+    window_title: str
+    process_name: str
+    rect: list[int] | None = None
+
+    @property
+    def target_id(self) -> str:
+        raw = f"{self.desktop_pid}|{self.hwnd}|{self.window_title}".encode("utf-8")
+        return hashlib.sha256(raw).hexdigest()[:16]
+
+    def to_dict(self) -> dict:
+        return {
+            "desktop_pid": self.desktop_pid,
+            "hwnd": self.hwnd,
+            "window_title": self.window_title,
+            "process_name": self.process_name,
+            "rect": self.rect,
+            "target_id": self.target_id,
+            "lifecycle_owner": "external",
+            "attach_kind": "desktop",
+            "control_channel": "comsol.java-shell-uia",
+        }
+
+
+def _default_windows_provider() -> list[dict]:
+    try:
+        from sim.gui import _pywinauto_tools  # type: ignore
+    except Exception as exc:  # noqa: BLE001 - import varies by host
+        raise TargetResolutionError(
+            "uia_unavailable",
+            f"sim.gui UIA helpers are unavailable: {exc}",
+        ) from exc
+
+    result = _pywinauto_tools.list_windows(())
+    if not result.get("ok"):
+        raise TargetResolutionError(
+            "uia_unavailable",
+            str(result.get("error") or "failed to enumerate windows"),
+        )
+    return list(result.get("windows") or [])
+
+
+def _looks_like_comsol_desktop(row: dict) -> bool:
+    proc = str(row.get("proc") or "").lower()
+    title = str(row.get("title") or "")
+    lowered_title = title.lower()
+    if "comsol" not in proc and "comsol" not in lowered_title:
+        return False
+    if "server" in lowered_title and "connect" in lowered_title:
+        return False
+    return True
+
+
+def _target_from_row(row: dict) -> DesktopTarget:
+    return DesktopTarget(
+        desktop_pid=int(row.get("pid") or 0),
+        hwnd=int(row.get("hwnd") or 0),
+        window_title=str(row.get("title") or ""),
+        process_name=str(row.get("proc") or ""),
+        rect=row.get("rect"),
+    )
+
+
+def find_desktops(
+    selector: DesktopSelector | None = None,
+    *,
+    windows_provider: Callable[[], Iterable[dict]] | None = None,
+) -> list[DesktopTarget]:
+    """Return visible COMSOL Desktop candidates matching ``selector``."""
+
+    selector = selector or DesktopSelector()
+    provider = windows_provider or _default_windows_provider
+    targets: list[DesktopTarget] = []
+    for row in provider():
+        if not _looks_like_comsol_desktop(row):
+            continue
+        target = _target_from_row(row)
+        if target.desktop_pid in selector.exclude_pids:
+            continue
+        if selector.desktop_pid is not None and target.desktop_pid != selector.desktop_pid:
+            continue
+        if selector.hwnd is not None and target.hwnd != selector.hwnd:
+            continue
+        if selector.window_title and selector.window_title not in target.window_title:
+            continue
+        targets.append(target)
+    return targets
+
+
+def resolve_target(
+    selector: DesktopSelector | None = None,
+    *,
+    windows_provider: Callable[[], Iterable[dict]] | None = None,
+) -> DesktopTarget:
+    """Resolve a single user-owned COMSOL Desktop target."""
+
+    candidates = find_desktops(selector, windows_provider=windows_provider)
+    if not candidates:
+        raise TargetResolutionError(
+            "target_not_found",
+            "No visible COMSOL Desktop window was found.",
+            [],
+        )
+    if len(candidates) > 1:
+        raise TargetResolutionError(
+            "target_ambiguous",
+            "Multiple COMSOL Desktop windows were found; specify desktop_pid or hwnd.",
+            [c.to_dict() for c in candidates],
+        )
+    return candidates[0]

--- a/tests/test_desktop_attach.py
+++ b/tests/test_desktop_attach.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sim_plugin_comsol.desktop_attach.audit import append_audit
+from sim_plugin_comsol.desktop_attach.shell import (
+    JavaShellError,
+    JavaShellChannel,
+    find_java_shell_in_snapshot,
+)
+from sim_plugin_comsol.desktop_attach.submit import SubmitError, validate_guardrail
+from sim_plugin_comsol.desktop_attach.target import (
+    DesktopSelector,
+    DesktopTarget,
+    TargetResolutionError,
+    find_desktops,
+    resolve_target,
+)
+
+
+def _windows():
+    return [
+        {"hwnd": 1, "pid": 10, "proc": "notepad.exe", "title": "notes", "rect": [0, 0, 1, 1]},
+        {
+            "hwnd": 2,
+            "pid": 20,
+            "proc": "comsol.exe",
+            "title": "COMSOL Multiphysics 6.4 - user_model.mph",
+            "rect": [0, 0, 100, 100],
+        },
+        {
+            "hwnd": 3,
+            "pid": 30,
+            "proc": "comsol.exe",
+            "title": "Connect to COMSOL Multiphysics Server",
+            "rect": [0, 0, 100, 100],
+        },
+    ]
+
+
+def test_find_desktops_filters_comsol_and_dialogs():
+    targets = find_desktops(windows_provider=_windows)
+    assert len(targets) == 1
+    assert targets[0].desktop_pid == 20
+    assert targets[0].to_dict()["lifecycle_owner"] == "external"
+    assert targets[0].to_dict()["control_channel"] == "comsol.java-shell-uia"
+
+
+def test_resolve_target_rejects_ambiguous():
+    def provider():
+        return _windows() + [
+            {
+                "hwnd": 4,
+                "pid": 40,
+                "proc": "comsol.exe",
+                "title": "COMSOL Multiphysics 6.4 - other.mph",
+                "rect": [0, 0, 100, 100],
+            }
+        ]
+
+    with pytest.raises(TargetResolutionError) as exc:
+        resolve_target(windows_provider=provider)
+    assert exc.value.code == "target_ambiguous"
+    assert len(exc.value.candidates) == 2
+
+
+def test_resolve_target_can_exclude_known_pids():
+    selector = DesktopSelector(exclude_pids=frozenset({20}))
+    with pytest.raises(TargetResolutionError) as exc:
+        resolve_target(selector, windows_provider=_windows)
+    assert exc.value.code == "target_not_found"
+
+
+def _snapshot():
+    return {
+        "ok": True,
+        "windows": [
+            {
+                "hwnd": 2,
+                "pid": 20,
+                "proc": "comsol.exe",
+                "title": "COMSOL Multiphysics 6.4 - user_model.mph",
+                "controls": [
+                    {"name": "Model Builder", "control_type": "Pane", "handle": 100},
+                    {
+                        "name": "Java Shell",
+                        "control_type": "Pane",
+                        "handle": 200,
+                        "children": [
+                            {"name": "Output", "control_type": "Document", "handle": 201},
+                            {
+                                "name": "",
+                                "control_type": "Edit",
+                                "handle": 202,
+                                "class_name": "SyntaxEditor",
+                                "rect": [441, 745, 795, 765],
+                            },
+                        ],
+                    },
+                ],
+            }
+        ],
+    }
+
+
+def test_find_java_shell_uses_last_editable_descendant():
+    target = DesktopTarget(20, 2, "COMSOL Multiphysics 6.4 - user_model.mph", "comsol.exe")
+    channel = find_java_shell_in_snapshot(_snapshot(), target)
+    assert channel.pane_handle == 200
+    assert channel.input_handle == 202
+    assert channel.input_control_type == "Edit"
+    assert channel.input_class_name == "SyntaxEditor"
+    assert channel.input_rect == [441, 745, 795, 765]
+
+
+def test_find_java_shell_prefers_syntax_editor_over_later_document():
+    target = DesktopTarget(20, 2, "COMSOL Multiphysics 6.4 - user_model.mph", "comsol.exe")
+    snapshot = _snapshot()
+    snapshot["windows"][0]["controls"][1]["children"].append(
+        {"name": "Late output", "control_type": "Document", "handle": 203}
+    )
+    channel = find_java_shell_in_snapshot(snapshot, target)
+    assert channel.input_handle == 202
+
+
+def test_find_java_shell_reports_missing_shell():
+    target = DesktopTarget(20, 2, "COMSOL Multiphysics 6.4 - user_model.mph", "comsol.exe")
+    snapshot = _snapshot()
+    snapshot["windows"][0]["controls"] = []
+    with pytest.raises(JavaShellError) as exc:
+        find_java_shell_in_snapshot(snapshot, target)
+    assert exc.value.code == "shell_not_visible"
+
+
+def test_guardrail_allows_model_lines_and_comments():
+    validate_guardrail(
+        """
+        // comment
+        model.param().set("probe_x", "1");
+
+        model.component("comp1").geom().run();
+        """
+    )
+
+
+def test_guardrail_rejects_non_model_lines():
+    with pytest.raises(SubmitError) as exc:
+        validate_guardrail('ModelUtil.showProgress(true);')
+    assert exc.value.code == "guardrail_rejected"
+
+
+def test_append_audit_writes_capped_record(tmp_path: Path):
+    target = DesktopTarget(20, 2, "COMSOL Multiphysics 6.4 - user_model.mph", "comsol.exe")
+    channel = JavaShellChannel(target=target, pane_handle=200, input_handle=202, input_control_type="Edit")
+    path = append_audit(channel, 'model.param().set("probe_x", "1");', "submitted", audit_dir=tmp_path)
+    row = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
+    assert row["desktop_pid"] == 20
+    assert row["exec_language"] == "java-shell"
+    assert row["status"] == "submitted"
+    assert row["code_sha256"]

--- a/tests/test_wheel_contents.py
+++ b/tests/test_wheel_contents.py
@@ -35,6 +35,8 @@ def test_wheel_contains_skills(tmp_path: Path) -> None:
     required = {
         "sim_plugin_comsol/__init__.py",
         "sim_plugin_comsol/driver.py",
+        "sim_plugin_comsol/desktop_attach/__init__.py",
+        "sim_plugin_comsol/desktop_attach/cli.py",
         "sim_plugin_comsol/_skills/comsol/SKILL.md",
         "sim_plugin_comsol/_skills/comsol/base/reference/runtime_introspection.md",
         "sim_plugin_comsol/_skills/comsol/base/workflows/debug_failed_exec.md",


### PR DESCRIPTION
## Summary

- Add `sim-comsol-attach`, a standalone helper for attaching to ordinary COMSOL Desktop through the Java Shell instead of launching `mphclient`.
- Add `open`, `health`, `snapshot`, and `exec` flows for normal Desktop startup, Blank Model selection, Java Shell discovery, guarded Java submission, and audit logging.
- Update the bundled `comsol-sim` skill so interactive Windows work defaults to the human-collaboration Desktop attach path, while `sim connect --solver comsol` remains the path for JPype/inspect/server-managed workflows.
- Add focused desktop attach tests and include the helper package in the wheel contents check.

## Validation

- `.\.venv\Scripts\python.exe -m pytest --basetemp .pytest_basetemp\desktop_attach tests\test_desktop_attach.py -q` -> 9 passed
- `.\.venv\Scripts\python.exe -m pytest --basetemp .pytest_basetemp\all -q` -> 95 passed, 1 skipped
- `.\.venv\Scripts\python.exe -m pytest --basetemp .pytest_basetemp\wheel_contents tests\test_wheel_contents.py -q` -> 1 passed
- `.\.venv\Scripts\python.exe -m compileall -q src\sim_plugin_comsol\desktop_attach`
- `.\.venv\Scripts\python.exe -m sim_plugin_comsol.desktop_attach open --help`
- Live COMSOL Desktop smoke on Windows: ordinary `comsol.exe` launch, Blank Model selection, Java Shell activation, Java Shell exec submission, 2D heat-transfer model solve, and plot visualization.

## Notes

This is intentionally outside the existing `ComsolDriver` lifecycle so users can keep the real-time visible Desktop mode while we iterate on the fuller runtime integration.