### PR TITLE
[codex] Clean public README wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 0.1.6 - Unreleased
+## 0.1.7 - 2026-05-03
+
+- Remove internal test-implementation wording from the public README/PyPI description.
+
+## 0.1.6 - 2026-05-03
 
 - Prepare public PyPI publishing through GitHub Trusted Publishing.
 - Add the `sim-comsol-attach` helper for realtime-visible COMSOL Desktop collaboration.

--- a/README.md
+++ b/README.md
@@ -59,8 +59,6 @@ uv sync
 uv run pytest
 ```
 
-Most tests run without COMSOL installed (they exercise the driver protocol surface against fixtures and use in-memory ZIP archives for the MPH-file probe). The end-to-end tests require a real COMSOL license and are skipped otherwise.
-
 ## License
 
 Apache-2.0. See [LICENSE](LICENSE) and [LICENSE-NOTICE.md](LICENSE-NOTICE.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sim-plugin-comsol"
-version = "0.1.6"
+version = "0.1.7"
 description = "COMSOL Multiphysics driver for sim-cli, distributed as an out-of-tree plugin"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -912,7 +912,7 @@ wheels = [
 
 [[package]]
 name = "sim-plugin-comsol"
-version = "0.1.6"
+version = "0.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "mph" },


### PR DESCRIPTION
## Summary

- Remove internal test-implementation wording from the public README/PyPI description.
- Bump to `0.1.7` so the PyPI project page can be refreshed with the cleaned README.
- Mark `0.1.6` as released in the changelog.

## Validation

- `.\.venv\Scripts\python.exe -m pytest --basetemp .pytest_basetemp\readme_cleanup tests -q` -> 95 passed, 1 skipped
- `.\.venv\Scripts\python.exe -m build --wheel --outdir .pytest_basetemp\readme_cleanup_dist` -> built `sim_plugin_comsol-0.1.7-py3-none-any.whl`