### PR TITLE
[codex] Unify COMSOL desktop attach command path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,6 @@ jobs:
           python-version: "3.12"
 
       - name: Run tests
-        run: uv run --extra test pytest --basetemp .pytest_basetemp/ci -q
+        run: |
+          mkdir -p .pytest_basetemp
+          uv run --extra test pytest --basetemp .pytest_basetemp/ci -q

--- a/src/sim_plugin_comsol/_skills/comsol/SKILL.md
+++ b/src/sim_plugin_comsol/_skills/comsol/SKILL.md
@@ -261,12 +261,16 @@ refresh a separately opened COMSOL Desktop window.
 ### Ordinary Desktop attach helper
 
 For interactive Windows work, the normal user-facing default is the
-standalone helper:
+standalone helper. Agents and humans must use the same command path:
+prefer `uvx --from sim-plugin-comsol sim-comsol-attach ...` over relying
+on a PATH-installed `sim-comsol-attach.exe`. This keeps development,
+documentation, and user reproduction aligned even when Python user
+Scripts directories are not on PATH.
 
 ```powershell
-sim-comsol-attach open --json --timeout 120
-sim-comsol-attach health --json
-sim-comsol-attach exec --file step.java --json
+uvx --from sim-plugin-comsol sim-comsol-attach open --json --timeout 120
+uvx --from sim-plugin-comsol sim-comsol-attach health --json
+uvx --from sim-plugin-comsol sim-comsol-attach exec --file step.java --json
 ```
 
 `open` launches normal `comsol.exe` if no suitable Desktop exists,


### PR DESCRIPTION
## Summary

- Update the COMSOL skill's Desktop attach instructions to use `uvx --from sim-plugin-comsol sim-comsol-attach ...`.
- Document that agents and humans should use the same command path instead of relying on a PATH-installed `sim-comsol-attach.exe`.

## Why

The standalone `sim-comsol-attach` entry point can be installed in Python's user Scripts directory, which may not be present in a user's shell PATH. Using `uvx --from sim-plugin-comsol ...` gives users and agents the same reproducible invocation path and avoids falling back to `sim connect` when Desktop attach is the intended human-collaboration mode.

## Validation

- `uv run pytest tests/test_wheel_contents.py tests/test_desktop_attach.py`
  - First run hit a Windows Temp permission issue under `C:\Users\jiwei\AppData\Local\Temp\pytest-of-jiwei`.
  - Reran with `TMP`/`TEMP` pointed at a repo-local temporary directory: 10 passed.