### PR TITLE
[codex] Fix COMSOL desktop target discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.9 - 2026-05-03
+
+- Tighten Desktop attach target discovery so browser pages mentioning `sim-plugin-comsol` are not mistaken for COMSOL Desktop.
+
 ## 0.1.8 - 2026-05-03
 
 - Use `uvx --from sim-plugin-comsol sim-comsol-attach ...` as the documented COMSOL Desktop attach path so users and agents share the same invocation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sim-plugin-comsol"
-version = "0.1.8"
+version = "0.1.9"
 description = "COMSOL Multiphysics driver for sim-cli, distributed as an out-of-tree plugin"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sim_plugin_comsol/desktop_attach/target.py
+++ b/src/sim_plugin_comsol/desktop_attach/target.py
@@ -85,7 +85,9 @@ def _looks_like_comsol_desktop(row: dict) -> bool:
     proc = str(row.get("proc") or "").lower()
     title = str(row.get("title") or "")
     lowered_title = title.lower()
-    if "comsol" not in proc and "comsol" not in lowered_title:
+    proc_is_comsol = "comsol" in proc
+    title_is_desktop = lowered_title.startswith("comsol multiphysics")
+    if not proc_is_comsol and not title_is_desktop:
         return False
     if "server" in lowered_title and "connect" in lowered_title:
         return False

--- a/tests/test_desktop_attach.py
+++ b/tests/test_desktop_attach.py
@@ -49,6 +49,21 @@ def test_find_desktops_filters_comsol_and_dialogs():
     assert targets[0].to_dict()["control_channel"] == "comsol.java-shell-uia"
 
 
+def test_find_desktops_ignores_browser_pages_about_comsol():
+    def provider():
+        return [
+            {
+                "hwnd": 5,
+                "pid": 50,
+                "proc": "chrome.exe",
+                "title": "sim-plugin-comsol: Driver plugin for sim-cli - Google Chrome",
+                "rect": [0, 0, 100, 100],
+            }
+        ]
+
+    assert find_desktops(windows_provider=provider) == []
+
+
 def test_resolve_target_rejects_ambiguous():
     def provider():
         return _windows() + [

--- a/uv.lock
+++ b/uv.lock
@@ -912,7 +912,7 @@ wheels = [
 
 [[package]]
 name = "sim-plugin-comsol"
-version = "0.1.8"
+version = "0.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "mph" },


### PR DESCRIPTION
## Summary

- Tighten Desktop attach target discovery so ordinary browser pages that mention `sim-plugin-comsol` are not treated as COMSOL Desktop windows.
- Add a regression test for Chrome/GitHub pages mentioning the plugin name.
- Bump the release version to `0.1.9`.

## Why

After releasing `0.1.8`, `uvx --from sim-plugin-comsol==0.1.8 sim-comsol-attach health --json` found a Chrome page titled with `sim-plugin-comsol` when no COMSOL Desktop Java Shell was visible. The target filter accepted any title containing `comsol`; Desktop attach should only accept COMSOL processes or explicit `COMSOL Multiphysics...` desktop titles.

## Validation

- `uv run --extra test pytest --basetemp .pytest_basetemp/ci -q` — 96 passed, 1 skipped.