### PR TITLE
Make COMSOL plugin Desktop attach first-class

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # sim-plugin-comsol
 
-[COMSOL Multiphysics](https://www.comsol.com) driver for [sim-cli](https://github.com/svd-ai-lab/sim-cli), distributed as an out-of-tree plugin via Python `entry_points`.
+[COMSOL Multiphysics](https://www.comsol.com) driver and Desktop attach
+workflow for [sim-cli](https://github.com/svd-ai-lab/sim-cli), distributed as
+an out-of-tree plugin via Python `entry_points`.
 
 The COMSOL solver and its `mph` Python binding are not bundled — you supply them yourself. See [LICENSE-NOTICE.md](LICENSE-NOTICE.md).
 
@@ -10,7 +12,19 @@ The COMSOL solver and its `mph` Python binding are not bundled — you supply th
 pip install sim-plugin-comsol
 ```
 
-After install, sim-cli auto-discovers the driver:
+After install, agents can drive an already-open COMSOL Desktop through the
+standalone attach helper:
+
+```powershell
+sim-comsol-attach open --json --timeout 120
+sim-comsol-attach health --json
+sim-comsol-attach exec --file step.java --json
+```
+
+Use this path first when the user has COMSOL Desktop open, wants to watch the
+model update, or may intervene manually during the session.
+
+sim-cli also auto-discovers the server-backed driver:
 
 ```bash
 sim drivers | grep comsol
@@ -23,17 +37,43 @@ You can also install through sim-cli's plugin command:
 sim plugin install sim-plugin-comsol
 ```
 
-For realtime-visible COMSOL Desktop collaboration on Windows, use the
-standalone attach helper:
+## Agent quickstart
 
-```powershell
-sim-comsol-attach open --json --timeout 120
-sim-comsol-attach exec --file step.java --json
+This repository is intended to be the complete COMSOL agent bundle. A
+receiving agent should not need a separate skill checkout for COMSOL work; the
+driver, Desktop attach helper, and COMSOL skill are bundled here.
+The only runtime dependency from the sim stack is the installed sim CLI/core
+package pulled in by this plugin.
+
+For source-tree development:
+
+```bash
+git clone https://github.com/svd-ai-lab/sim-plugin-comsol
+cd sim-plugin-comsol
+uv sync
+uv run sim drivers
+uv run sim check comsol
+```
+
+The bundled skill entry point is:
+
+```text
+src/sim_plugin_comsol/_skills/comsol/SKILL.md
+```
+
+Use it as the first agent instruction for COMSOL tasks, for example:
+
+```text
+Use the bundled COMSOL skill in this repository. If COMSOL Desktop is already
+open or the user wants visible co-editing, use Desktop attach first. Use the
+sim runtime only when structured inspect, driver-managed artifacts, or
+server-backed state are needed. Build and solve the requested model one bounded
+step at a time.
 ```
 
 ## How it works
 
-The plugin registers via three entry-point groups:
+The plugin registers the Desktop attach CLI plus three entry-point groups:
 
 ```toml
 [project.entry-points."sim.drivers"]
@@ -44,11 +84,15 @@ comsol = "sim_plugin_comsol:skills_dir"
 
 [project.entry-points."sim.plugins"]
 comsol = "sim_plugin_comsol:plugin_info"
+
+[project.scripts]
+sim-comsol-attach = "sim_plugin_comsol.desktop_attach.cli:main"
 ```
 
 `sim.drivers` exposes the driver class; `sim.skills` exposes a directory
 of skill files bundled inside the wheel; `sim.plugins` exposes plugin
-metadata for discovery.
+metadata for discovery. `sim-comsol-attach` exposes the Desktop-first
+collaboration path.
 
 ## Develop
 

--- a/src/sim_plugin_comsol/_skills/comsol/SKILL.md
+++ b/src/sim_plugin_comsol/_skills/comsol/SKILL.md
@@ -1,26 +1,30 @@
 ---
 name: comsol-sim
-description: Use when working with COMSOL Multiphysics through the sim runtime or inspecting saved `.mph` artifacts — building, inspecting, debugging, and solving stateful COMSOL models through the JPype Java API, optionally with a human watching the COMSOL GUI client, plus offline `.mph` introspection without a JVM.
+description: Use when working with COMSOL Multiphysics through a user-visible Desktop attach workflow, the sim runtime, or saved `.mph` artifacts — controlling an already-open COMSOL Desktop through Java Shell for human-in-the-loop modeling, building/debugging/solving stateful COMSOL models through the JPype Java API when structured runtime inspection is needed, and performing offline `.mph` introspection without a JVM.
 ---
 
 # comsol-sim
 
-This file is the **COMSOL Multiphysics** index. Use the offline `.mph`
-inspection path for saved artifacts; use sim-cli for persistent live sessions
-that mutate, solve, or inspect the current JPype Java API model.
+This file is the **COMSOL Multiphysics** index. Default to Desktop attach for
+interactive human-in-the-loop COMSOL work, especially when the user already
+opened COMSOL Desktop or wants to watch and occasionally intervene. Use the
+offline `.mph` inspection path for saved artifacts. Use the sim runtime when
+the task needs persistent JPype state, structured `sim inspect`, managed
+artifacts, or server-backed execution.
 
-> **First, read [`../sim-cli/SKILL.md`](../sim-cli/SKILL.md)** — it owns
-> the shared runtime contract (session lifecycle, Step-0 version probe,
-> input classification, acceptance, escalation). This skill covers only
-> the COMSOL-specific layer on top of that contract.
+This skill is self-contained for COMSOL work. Do not require a separate skill
+checkout or an external sim-cli skill. Use this file for the COMSOL workflow,
+and load the plugin-bundled references below only when the task needs them.
 
 ---
 
 ## COMSOL-specific layered content
 
-After `sim connect --solver comsol` and the shared-skill Step-0 probe,
-the returned `session.versions` payload tells you which COMSOL-specific
-subfolders to load:
+For Desktop attach, start with `sim-comsol-attach open --json --timeout 120`
+or `sim-comsol-attach health --json`, then submit bounded Java Shell snippets.
+For the sim runtime, start with `sim check comsol`, then
+`sim connect --solver comsol`, then inspect `session.health`. The returned
+`session.versions` payload tells you which COMSOL-specific subfolders to load:
 
 ```json
 "session.versions": {
@@ -49,10 +53,11 @@ Larger engineering examples do not live in this plugin skill. Keep this
 plugin-owned content focused on the driver protocol, live introspection,
 debug loops, and the smallest smoke/reference workflow.
 
-Each numbered step is a self-contained snippet you submit via
-`sim exec` after `sim connect --solver comsol`. The snippets use the
-injected `model` object — they do NOT call `mph.start()` or open a
-client of their own.
+Each numbered step is a self-contained snippet for the sim runtime after
+`sim connect --solver comsol`. For Desktop attach, translate the same bounded
+modeling step into a Java Shell snippet against the visible Desktop model.
+Snippets use the provided `model` handle — they do NOT call `mph.start()` or
+open a client of their own.
 
 Before running a new or complex workflow, read
 [`base/reference/runtime_introspection.md`](base/reference/runtime_introspection.md)
@@ -91,7 +96,7 @@ Only after live introspection is insufficient, query the local COMSOL
 documentation that ships with every install:
 
 ```bash
-uv run --project <sim-skills>/comsol/doc-search sim-comsol-doc search "<term>" [--module <substring>]
+uv run --project src/sim_plugin_comsol/_skills/comsol/doc-search sim-comsol-doc search "<term>" [--module <substring>]
 ```
 
 `doc-search` runs in pure CPython: no live COMSOL session, no sim runtime,
@@ -100,7 +105,7 @@ and no JVM. It scans the installed COMSOL HTML help on disk.
 One-time setup on any host that has COMSOL installed:
 
 ```bash
-cd <sim-skills>/comsol/doc-search && uv sync
+cd src/sim_plugin_comsol/_skills/comsol/doc-search && uv sync
 ```
 
 (No index build step — each query scans the doc tree in parallel; typical
@@ -185,7 +190,7 @@ skips GUI actuation entirely.
 
 ## COMSOL-specific hard constraints
 
-These add to — do not replace — the shared skill's hard constraints.
+These hard constraints apply to every COMSOL task through this plugin.
 
 1. **Never call `mph.start()` or `client.create()` from a snippet.**
    sim-cli already started a COMSOL JVM and gave you a `model` handle.
@@ -193,8 +198,7 @@ These add to — do not replace — the shared skill's hard constraints.
 2. **Image export is broken on Windows.** Use the verification helpers
    referenced in the workflow READMEs (slice / probe extraction →
    numeric acceptance) instead of `model.result().export()` PNGs. The
-   shared skill's `acceptance.md` explains why numeric acceptance
-   beats visual acceptance anyway.
+   Numeric probes and exported data are more reliable acceptance checks.
 3. **Never hardcode COMSOL property names before inspecting the live
    node.** Prefer `sim inspect comsol.node.properties:<target>` or the
    raw Java `properties()` pattern before calling `set(...)`.
@@ -205,32 +209,35 @@ These add to — do not replace — the shared skill's hard constraints.
 
 ## Required protocol
 
-COMSOL through sim is a persistent, inspectable modeling session. Treat
-it as a live engineering state, not as a one-shot code generator.
+Treat COMSOL as a live engineering state, not as a one-shot code generator.
+Most user-facing sessions are human-in-the-loop Desktop sessions; keep the
+visible model coherent after every step.
 
 0. If the question is about a saved `.mph` (parameters, physics tags,
    solved/unsolved state, mesh size), use `inspect_mph(path)` first — no
    JVM and no `sim connect` needed. Skip to step 1 only if the model needs
    to be mutated or solved.
-1. Choose the control path. For interactive Windows work, default to the
-   human-collaboration path unless the task explicitly needs the driver
-   runtime:
-   - Use the standalone Desktop attach helper when the user wants ordinary,
-     realtime-visible COMSOL Desktop work, when they already opened Desktop,
-     or when avoiding the `mphclient` server login dialog matters.
+1. Choose the control path. Default to the human-collaboration path for
+   ordinary interactive work:
+   - Use the standalone Desktop attach helper when the user already opened
+     COMSOL Desktop, wants realtime-visible model edits, may intervene
+     manually, or wants to avoid the `mphclient` server login dialog.
    - Use `sim connect --solver comsol` only when you need `sim inspect`,
      JPype session state, driver-managed artifacts, headless/server
      execution, or compatibility with existing sim runtime workflows.
-2. Run the shared Step-0 version probe and read `session.versions`.
-3. Inspect `sim inspect session.health`.
-4. Inspect the baseline model with `sim inspect comsol.model.describe_text`
-   when available.
-5. Execute one bounded modeling step with `sim exec`.
-6. Inspect `sim inspect last.result`.
-7. Inspect the changed model state with
-   `sim inspect comsol.model.describe_text` and, when needed,
-   `sim inspect comsol.node.properties:<tag-or-dot-path>`.
-8. Continue only after the live model matches the intended geometry,
+2. For Desktop attach, run `sim-comsol-attach open --json --timeout 120` or
+   `sim-comsol-attach health --json`, then confirm the Java Shell channel is
+   ready.
+3. For sim runtime, run `sim check comsol`, connect if needed, and read
+   `session.versions` plus `sim inspect session.health`.
+4. Inspect the baseline state. In Desktop attach, use the visible Model
+   Builder, Graphics view, tables, and Java Shell output. In sim runtime, use
+   `sim inspect comsol.model.describe_text` when available.
+5. Execute one bounded modeling step.
+6. Inspect the result before continuing: visible Desktop state for attach;
+   `sim inspect last.result`, `comsol.model.describe_text`, and
+   `comsol.node.properties:<tag-or-dot-path>` for sim runtime.
+7. Continue only after the live model matches the intended geometry,
    materials, physics, mesh, study, and result state.
 
 For simple known-good smoke coverage, use the numbered snippets under
@@ -260,8 +267,8 @@ refresh a separately opened COMSOL Desktop window.
 
 ### Ordinary Desktop attach helper
 
-For interactive Windows work, the normal user-facing default is the
-standalone helper. Agents and humans must use the same command path:
+For interactive work, the normal user-facing default is the standalone helper.
+Agents and humans must use the same command path:
 prefer `uvx --from sim-plugin-comsol sim-comsol-attach ...` over relying
 on a PATH-installed `sim-comsol-attach.exe`. This keeps development,
 documentation, and user reproduction aligned even when Python user
@@ -283,6 +290,31 @@ against the visible Desktop model. Keep the same modeling discipline as
 `sim exec`: one layer at a time, verify the Desktop after each geometry,
 material, physics, mesh, solve, and plot step, then continue. The helper
 audits submissions under `.sim/comsol-desktop-attach/audit.jsonl`.
+
+COMSOL 6.4 Desktop gotchas:
+- User-opened model windows may be titled `Untitled.mph - COMSOL
+  Multiphysics`; target discovery must match titles containing `COMSOL
+  Multiphysics`, not only titles starting with it.
+- In the docked Java Shell, `Ctrl+Enter` is the reliable submit action. If a
+  compile/runtime exception leaves the shell rerunning stale input, close and
+  reopen the Java Shell pane before submitting corrected code.
+- Java Shell snippets can be denied writes by COMSOL's Security preference for
+  file-system access. Use in-model tables for data handoff, or have the user
+  enable file access before saving `.mph` files or exporting CSV/plots.
+- For result plots built from table data, the Java feature type is `Table`
+  under a `PlotGroup1D`, not `TableGraph`. Use
+  `m.result("<pg>").feature().create("<tag>", "Table")`, then set
+  `source="table"`, `table="<table_tag>"`, `xaxisdata="<column_index>"`,
+  `plotcolumninput="manual"`, and `plotcolumns=new String[]{"<column>"}`.
+  `TableFeature.setTableData(double[][])` can populate a small in-model table
+  when file export is blocked.
+- Do not repurpose a probe plot group for table plots when a clean display is
+  required. Probe plot groups can retain probe-specific render state and axis
+  cache. Prefer creating a fresh 1D plot group, or reusing an existing native
+  table-plot group from the model's results tree.
+- Avoid setting duplicate plot labels in Java Shell snippets; COMSOL throws a
+  duplicate-label exception before later plot setup lines run. Either remove the
+  old plot group first or leave the existing label unchanged.
 
 By default, `exec` rejects arbitrary Java lines that do not start from the
 COMSOL model surface. Use `--allow-arbitrary-java` only for deliberate

--- a/src/sim_plugin_comsol/_skills/comsol/doc-search/README.md
+++ b/src/sim_plugin_comsol/_skills/comsol/doc-search/README.md
@@ -7,7 +7,7 @@ the `com.comsol.help.*` Eclipse-help plugins that COMSOL ships on disk.
 ## Install
 
 ```bash
-cd sim-skills/comsol/doc-search
+cd src/sim_plugin_comsol/_skills/comsol/doc-search
 uv sync
 ```
 

--- a/src/sim_plugin_comsol/desktop_attach/target.py
+++ b/src/sim_plugin_comsol/desktop_attach/target.py
@@ -86,7 +86,7 @@ def _looks_like_comsol_desktop(row: dict) -> bool:
     title = str(row.get("title") or "")
     lowered_title = title.lower()
     proc_is_comsol = "comsol" in proc
-    title_is_desktop = lowered_title.startswith("comsol multiphysics")
+    title_is_desktop = "comsol multiphysics" in lowered_title
     if not proc_is_comsol and not title_is_desktop:
         return False
     if "server" in lowered_title and "connect" in lowered_title:

--- a/tests/test_desktop_attach.py
+++ b/tests/test_desktop_attach.py
@@ -49,6 +49,23 @@ def test_find_desktops_filters_comsol_and_dialogs():
     assert targets[0].to_dict()["control_channel"] == "comsol.java-shell-uia"
 
 
+def test_find_desktops_accepts_saved_model_title_suffix():
+    def provider():
+        return [
+            {
+                "hwnd": 6,
+                "pid": 60,
+                "proc": "ComsolUI.exe",
+                "title": "Untitled.mph - COMSOL Multiphysics",
+                "rect": [0, 0, 100, 100],
+            }
+        ]
+
+    targets = find_desktops(windows_provider=provider)
+    assert len(targets) == 1
+    assert targets[0].desktop_pid == 60
+
+
 def test_find_desktops_ignores_browser_pages_about_comsol():
     def provider():
         return [

--- a/tests/test_wheel_contents.py
+++ b/tests/test_wheel_contents.py
@@ -38,7 +38,11 @@ def test_wheel_contains_skills(tmp_path: Path) -> None:
         "sim_plugin_comsol/desktop_attach/__init__.py",
         "sim_plugin_comsol/desktop_attach/cli.py",
         "sim_plugin_comsol/_skills/comsol/SKILL.md",
+        "sim_plugin_comsol/_skills/comsol/doc-search/README.md",
+        "sim_plugin_comsol/_skills/comsol/doc-search/src/sim_comsol_doc/cli.py",
+        "sim_plugin_comsol/_skills/comsol/base/reference/java_api_patterns.md",
         "sim_plugin_comsol/_skills/comsol/base/reference/runtime_introspection.md",
+        "sim_plugin_comsol/_skills/comsol/base/workflows/model_review_loop.md",
         "sim_plugin_comsol/_skills/comsol/base/workflows/debug_failed_exec.md",
     }
     missing = required - names


### PR DESCRIPTION
## Summary
- Make Desktop attach the first-class/default COMSOL workflow for agent handoff when the user already has COMSOL Desktop open, wants visible co-editing, or may intervene manually.
- Match COMSOL Desktop windows whose titles contain `COMSOL Multiphysics`, including saved/user-opened titles like `Untitled.mph - COMSOL Multiphysics`.
- Add a regression test for the suffix-title Desktop window pattern.
- Make the COMSOL plugin more self-contained for agent handoff: add a README agent quickstart, remove bundled skill dependencies on external skill checkouts, point doc-search instructions at the plugin-local path, and assert more bundled skill resources ship in the wheel.
- Document COMSOL Java Shell gotchas from the Tesla 18650 P2D polarization workflow: Ctrl+Enter submission, stale shell recovery, file-write security, table plot feature type, and plot group reuse issues.

## Verification
- `uv run pytest tests\test_desktop_attach.py tests\test_wheel_contents.py -q --basetemp .pytest_tmp`

Note: the repo-local `--basetemp` avoids a Windows temp-directory permission issue under the default pytest temp root.