### PR TITLE
[codex] Accept no_gui UI mode for COMSOL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.10 - 2026-05-03
+
+- Accept the sim-cli default `ui_mode=no_gui` as the canonical COMSOL no-visible-UI mode.
+
 ## 0.1.9 - 2026-05-03
 
 - Tighten Desktop attach target discovery so browser pages mentioning `sim-plugin-comsol` are not mistaken for COMSOL Desktop.

--- a/src/sim_plugin_comsol/_skills/comsol/SKILL.md
+++ b/src/sim_plugin_comsol/_skills/comsol/SKILL.md
@@ -230,7 +230,7 @@ visible model coherent after every step.
      COMSOL Desktop, wants realtime-visible model edits, may intervene
      manually, or wants to avoid the `mphclient` server login dialog.
    - Use `sim connect --solver comsol` only when you need `sim inspect`,
-     JPype session state, driver-managed artifacts, headless/server
+     JPype session state, driver-managed artifacts, no-GUI/server
      execution, or compatibility with existing sim runtime workflows.
 2. For Desktop attach, run `sim-comsol-attach open --json --timeout 120` or
    `sim-comsol-attach health --json`, then confirm the Java Shell channel is
@@ -260,8 +260,8 @@ COMSOL has several visual surfaces. Do not collapse them into one
 
 | Mode | What it means | Live with agent edits? |
 |---|---|---|
-| `headless` | `comsolmphserver` API session with no intentional visible windows. | Yes, API session only. |
-| `server-graphics` | `comsolmphserver -graphics`; plot windows may appear when a result plot is run. This is the current default effective mode. Legacy `ui_mode=gui` is an alias for this. | Yes for the server-side model, but there is no Model Builder tree. |
+| `no_gui` | `comsolmphserver` API session with no intentional visible windows. This is the canonical sim-cli default. | Yes, API session only. |
+| `server-graphics` | `comsolmphserver -graphics`; plot windows may appear when a result plot is run. `ui_mode=gui` is an alias for this. | Yes for the server-side model, but there is no Model Builder tree. |
 | `desktop-inspection` | Save a `.mph` artifact, then open it in full COMSOL Desktop / Model Builder. | No. It is an inspection copy unless explicitly reloaded. |
 | `shared-desktop` | Full COMSOL Desktop attached to the same server, with the agent binding to the Desktop's active model tag. Request from sim-cli with `--driver-option visual_mode=shared-desktop`. | Yes, when `model_builder_live: true`. |
 | `desktop-attach` | Ordinary COMSOL Desktop, controlled through the Java Shell UIA channel via `sim-comsol-attach`. No `mphclient`, no shared server login dialog. | Yes, in the visible Desktop model, but without `sim inspect`/JPype session introspection. |

--- a/src/sim_plugin_comsol/driver.py
+++ b/src/sim_plugin_comsol/driver.py
@@ -65,14 +65,15 @@ class ComsolLifecycleError(RuntimeError):
 
 
 _COMSOL_UI_MODE_ALIASES = {
-    "": "server-graphics",
+    "": "no_gui",
+    "no_gui": "no_gui",
+    "no-gui": "no_gui",
+    "nogui": "no_gui",
     "gui": "server-graphics",
     "visible": "server-graphics",
     "graphics": "server-graphics",
     "server_graphics": "server-graphics",
     "server-graphics": "server-graphics",
-    "headless": "headless",
-    "none": "headless",
     "shared_desktop": "shared-desktop",
     "shared-desktop": "shared-desktop",
     "desktop": "server-graphics",
@@ -468,9 +469,9 @@ class ComsolDriver:
         # Sim dir for probe workdir (screenshots, workdir-diff baseline)
         self._sim_dir: Path = Path(os.environ.get("SIM_DIR") or (Path.cwd() / ".sim"))
         # InspectProbe list — baseline 9-channel (GUI off). launch() will
-        # flip GUI probes on if ui_mode='gui'/'desktop'.
+        # flip GUI probes on for server-graphics/shared-desktop modes.
         self.probes: list = _default_comsol_probes(enable_gui=False)
-        self._gui = None  # GuiController; set at launch() when ui_mode=gui
+        self._gui = None  # GuiController; set at launch() for visible modes.
 
     @property
     def name(self) -> str:
@@ -788,7 +789,7 @@ class ComsolDriver:
         return effective, note, visual
 
     def _ui_capabilities(self, effective_ui_mode: str | None = None) -> dict:
-        mode = effective_ui_mode or self._ui_mode or "headless"
+        mode = effective_ui_mode or self._ui_mode or "no_gui"
         server_graphics = mode == "server-graphics"
         shared_desktop = mode == "shared-desktop"
         return {
@@ -1087,7 +1088,7 @@ class ComsolDriver:
             return {
                 "ok": True,
                 "modes": {
-                    "headless": "COMSOL server API session without intentional visible UI.",
+                    "no_gui": "COMSOL server API session without intentional visible UI.",
                     "server-graphics": (
                         "COMSOL server API session with server-side graphics; "
                         "plot windows may be visible, but Model Builder is not "
@@ -1131,7 +1132,7 @@ class ComsolDriver:
     def launch(
         self,
         mode: str = "solver",
-        ui_mode: str = "gui",
+        ui_mode: str = "no_gui",
         processors: int = 2,
         comsol_root: str | None = None,
         user: str | None = None,
@@ -1358,7 +1359,7 @@ class ComsolDriver:
         self._last_health = self.health()
 
         # Flip probes to GUI-aware variant + construct gui actuation facade
-        # when visible COMSOL windows may appear. Headless launches skip both.
+        # when visible COMSOL windows may appear. no_gui launches skip both.
         gui_mode = effective_ui_mode in {"server-graphics", "shared-desktop"}
         if gui_mode:
             self.probes = _default_comsol_probes(enable_gui=True)

--- a/tests/test_comsol_driver.py
+++ b/tests/test_comsol_driver.py
@@ -153,6 +153,14 @@ class TestRunFile:
 
 
 class TestLifecycleDiagnostics:
+    def test_cli_no_gui_mode_is_canonical_no_gui(self):
+        driver = ComsolDriver()
+
+        effective, note = driver._normalize_ui_mode("no_gui")
+
+        assert effective == "no_gui"
+        assert note is None
+
     def test_legacy_gui_mode_is_server_graphics_alias(self):
         driver = ComsolDriver()
 
@@ -296,10 +304,10 @@ class TestLifecycleDiagnostics:
         driver._attach_only = True
         driver._active_model_tag = "Model1"
         driver._port = 65000
-        driver._ui_mode = "headless"
+        driver._ui_mode = "no_gui"
         driver._launch_options = {
             "requested_ui_mode": "no_gui",
-            "ui_mode": "headless",
+            "ui_mode": "no_gui",
             "attach_only": True,
             "server_owner": "external",
             "server_host": "localhost",
@@ -346,8 +354,10 @@ class TestLifecycleDiagnostics:
         modes = driver.query("ui.modes")
 
         assert modes["ok"] is True
+        assert "no_gui" in modes["modes"]
         assert "server-graphics" in modes["modes"]
         assert "shared-desktop" in modes["modes"]
+        assert modes["aliases"]["no_gui"] == "no_gui"
         assert modes["aliases"]["gui"] == "server-graphics"
 
 


### PR DESCRIPTION
## Summary

- Make `no_gui` the canonical COMSOL no-visible-UI mode so the plugin accepts the sim-cli default.
- Keep COMSOL-specific visible modes separate: `ui_mode=gui` still resolves to `server-graphics`, and `visual_mode=shared-desktop` remains the full Desktop path.
- Update UI-mode query metadata, regression coverage, bundled skill wording, and changelog.

## Why

`sim connect --solver comsol` uses the generic sim-cli default `ui_mode=no_gui` and forwards it unchanged to `driver.launch(...)`. The COMSOL plugin previously used `headless` as its canonical no-visible-UI term and rejected `no_gui`, causing the default CLI path to fail with an unknown UI-mode error.

## Validation

- `uv run pytest tests\test_comsol_driver.py -q --basetemp .pytest_tmp\ui_mode_contract` -> 30 passed
- `$env:PYTHONUTF8='1'; python C:\Users\jiwei\.codex\skills\.system\skill-creator\scripts\quick_validate.py src\sim_plugin_comsol\_skills\comsol` -> Skill is valid
- `git diff --cached --check`