### PR TITLE
[codex] Prefer shared-desktop COMSOL guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.11 - 2026-05-04
+
+- Prefer COMSOL `shared-desktop` mode for reliable live GUI collaboration.
+- Add `session.health.live_model_binding` to show whether the driver model handle is bound to the Desktop active model tag.
+- Warn when shared-desktop snippets create or switch to sidecar models that the visible COMSOL Desktop may not display.
+
 ## 0.1.10 - 2026-05-03
 
 - Accept the sim-cli default `ui_mode=no_gui` as the canonical COMSOL no-visible-UI mode.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,25 @@ pip install sim-plugin-comsol
 ```
 
 After install, agents can drive an already-open COMSOL Desktop through the
-standalone attach helper:
+server-backed driver. Use this path first when the user wants to watch the
+same live model that the agent is building, inspecting, or solving:
+
+```powershell
+sim connect --solver comsol --ui-mode gui --driver-option visual_mode=shared-desktop
+sim inspect session.health
+sim exec --file step.py
+```
+
+`shared-desktop` starts `comsolmphserver`, attaches a full COMSOL Desktop
+client to that server, and binds agent snippets to the Desktop active model
+tag. `session.health` should report `model_builder_live: true` and a
+`live_model_binding.ok` value of `true` before relying on the GUI as a live
+view of agent edits.
+
+The standalone Java Shell attach helper remains available as a fallback for
+ordinary COMSOL Desktop windows that are already open, when switching to an
+`mphclient` session is undesirable, or when the task is a small
+human-in-the-loop edit:
 
 ```powershell
 sim-comsol-attach open --json --timeout 120
@@ -21,8 +39,9 @@ sim-comsol-attach health --json
 sim-comsol-attach exec --file step.java --json
 ```
 
-Use this path first when the user has COMSOL Desktop open, wants to watch the
-model update, or may intervene manually during the session.
+Use this fallback for bounded visible edits and quick checks. Prefer
+`shared-desktop` for reliable multi-step model building, solving, structured
+inspection, and repeatable agent workflows.
 
 sim-cli also auto-discovers the server-backed driver:
 
@@ -64,11 +83,12 @@ src/sim_plugin_comsol/_skills/comsol/SKILL.md
 Use it as the first agent instruction for COMSOL tasks, for example:
 
 ```text
-Use the bundled COMSOL skill in this repository. If COMSOL Desktop is already
-open or the user wants visible co-editing, use Desktop attach first. Use the
-sim runtime only when structured inspect, driver-managed artifacts, or
-server-backed state are needed. Build and solve the requested model one bounded
-step at a time.
+Use the bundled COMSOL skill in this repository. If the user wants reliable
+visible co-editing, use the sim runtime with visual_mode=shared-desktop first
+and verify session.health live_model_binding.ok. Use Java Shell Desktop attach
+only for already-open ordinary Desktop sessions, small edits, or
+human-in-the-loop fallback work. Build and solve the requested model one
+bounded step at a time.
 ```
 
 ## How it works

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sim-plugin-comsol"
-version = "0.1.10"
+version = "0.1.11"
 description = "COMSOL Multiphysics driver for sim-cli, distributed as an out-of-tree plugin"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sim_plugin_comsol/_skills/comsol/SKILL.md
+++ b/src/sim_plugin_comsol/_skills/comsol/SKILL.md
@@ -1,16 +1,17 @@
 ---
 name: comsol-sim
-description: Use when working with COMSOL Multiphysics through a user-visible Desktop attach workflow, the sim runtime, or saved `.mph` artifacts — controlling an already-open COMSOL Desktop through Java Shell for human-in-the-loop modeling, building/debugging/solving stateful COMSOL models through the JPype Java API when structured runtime inspection is needed, and performing offline `.mph` introspection without a JVM.
+description: Use when working with COMSOL Multiphysics through the sim runtime, shared-desktop client-server GUI collaboration, a fallback Desktop attach workflow, or saved `.mph` artifacts — building/debugging/solving stateful COMSOL models through the JPype Java API when structured runtime inspection is needed, controlling an already-open ordinary Desktop through Java Shell for small human-in-the-loop edits, and performing offline `.mph` introspection without a JVM.
 ---
 
 # comsol-sim
 
 This file is the **COMSOL Multiphysics** index. Use the sim runtime/JPype path
-for serious model building, solving, inspection, and saved `.mph` artifacts.
-Use Desktop attach for small user-visible edits in an already-open COMSOL
-Desktop, quick visual checks, or human-in-the-loop interventions. Use the
-offline `.mph` inspection path for saved artifacts when no live COMSOL session
-is needed.
+for serious model building, solving, inspection, saved `.mph` artifacts, and
+reliable live GUI collaboration through `visual_mode=shared-desktop`. Use
+Desktop attach as a fallback for small user-visible edits in an already-open
+ordinary COMSOL Desktop, quick visual checks, or human-in-the-loop
+interventions. Use the offline `.mph` inspection path for saved artifacts when
+no live COMSOL session is needed.
 
 This skill is self-contained for COMSOL work. Do not require a separate skill
 checkout or an external sim-cli skill. Use this file for the COMSOL workflow,
@@ -24,13 +25,23 @@ Choose the control path first:
 
 | Path | Use it for | Avoid it for |
 |---|---|---|
-| sim runtime / JPype | Building, solving, inspecting, debugging, saving `.mph`, and repeatable case generation. | Editing the exact Desktop model the user is currently looking at. |
-| Desktop attach / Java Shell | Small visible Desktop edits, quick plots/tables, and user-in-the-loop adjustments in an already-open COMSOL window. | Long builders, heavy debugging, or anything that needs reliable structured exceptions. |
+| sim runtime / JPype | Building, solving, inspecting, debugging, saving `.mph`, repeatable case generation, and reliable live GUI co-editing with `visual_mode=shared-desktop`. | Already-open ordinary Desktop sessions that the user does not want to reconnect as `mphclient`. |
+| Desktop attach / Java Shell | Fallback for small visible Desktop edits, quick plots/tables, and user-in-the-loop adjustments in an already-open ordinary COMSOL window. | Long builders, heavy debugging, or anything that needs reliable structured exceptions or server-side inspect. |
 | saved `.mph` inspection | Offline summaries, archive diffs, and artifact review without starting COMSOL. | Mutating live model state. |
 
 For the sim runtime, start with `sim check comsol`, then
-`sim connect --solver comsol`, then inspect `session.health`. For Desktop
-attach, start with `sim-comsol-attach open --json --timeout 120` or
+`sim connect --solver comsol`, then inspect `session.health`. When the user
+wants to watch the live Model Builder while the agent builds or solves, use:
+
+```bash
+sim connect --solver comsol --ui-mode gui --driver-option visual_mode=shared-desktop
+sim inspect session.health
+```
+
+Confirm `ui_capabilities.model_builder_live: true`,
+`active_model_tag`, and `live_model_binding.ok: true` before treating the GUI
+as synchronized with agent edits. For Desktop attach fallback, start with
+`sim-comsol-attach open --json --timeout 120` or
 `sim-comsol-attach health --json`, then submit bounded Java Shell snippets with
 `--submit-key ctrl_enter`. The returned `session.versions` payload tells you
 which COMSOL-specific subfolders to load:
@@ -224,14 +235,16 @@ visible model coherent after every step.
    solved/unsolved state, mesh size), use `inspect_mph(path)` first — no
    JVM and no `sim connect` needed. Skip to step 1 only if the model needs
    to be mutated or solved.
-1. Choose the control path. Default to the human-collaboration path for
-   ordinary interactive work:
-   - Use the standalone Desktop attach helper when the user already opened
-     COMSOL Desktop, wants realtime-visible model edits, may intervene
-     manually, or wants to avoid the `mphclient` server login dialog.
-   - Use `sim connect --solver comsol` only when you need `sim inspect`,
-     JPype session state, driver-managed artifacts, no-GUI/server
-     execution, or compatibility with existing sim runtime workflows.
+1. Choose the control path. Default to the sim runtime for reliable model
+   building, solving, and live GUI collaboration:
+   - Use `sim connect --solver comsol --ui-mode gui --driver-option
+     visual_mode=shared-desktop` when the user wants real-time Model Builder
+     visibility and the agent needs structured `sim inspect`/JPype state.
+   - Use the standalone Desktop attach helper only when the user already
+     opened ordinary COMSOL Desktop, wants to avoid the `mphclient` server
+     login/session switch, or needs a small human-in-the-loop edit.
+   - Use plain `sim connect --solver comsol` for no-GUI/server execution,
+     driver-managed artifacts, and existing sim runtime workflows.
 2. For Desktop attach, run `sim-comsol-attach open --json --timeout 120` or
    `sim-comsol-attach health --json`, then confirm the Java Shell channel is
    ready.
@@ -264,7 +277,7 @@ COMSOL has several visual surfaces. Do not collapse them into one
 | `server-graphics` | `comsolmphserver -graphics`; plot windows may appear when a result plot is run. `ui_mode=gui` is an alias for this. | Yes for the server-side model, but there is no Model Builder tree. |
 | `desktop-inspection` | Save a `.mph` artifact, then open it in full COMSOL Desktop / Model Builder. | No. It is an inspection copy unless explicitly reloaded. |
 | `shared-desktop` | Full COMSOL Desktop attached to the same server, with the agent binding to the Desktop's active model tag. Request from sim-cli with `--driver-option visual_mode=shared-desktop`. | Yes, when `model_builder_live: true`. |
-| `desktop-attach` | Ordinary COMSOL Desktop, controlled through the Java Shell UIA channel via `sim-comsol-attach`. No `mphclient`, no shared server login dialog. | Yes, in the visible Desktop model, but without `sim inspect`/JPype session introspection. |
+| `desktop-attach` | Fallback ordinary COMSOL Desktop path, controlled through the Java Shell UIA channel via `sim-comsol-attach`. No `mphclient`, no shared server login dialog. | Yes, in the visible Desktop model, but without `sim inspect`/JPype session introspection. |
 
 Use `sim inspect session.health` or `sim exec` target `session.health`
 to check `requested_ui_mode`, `effective_ui_mode`, `ui_capabilities`,
@@ -274,8 +287,8 @@ refresh a separately opened COMSOL Desktop window.
 
 ### Ordinary Desktop attach helper
 
-For interactive work, the normal user-facing default is the standalone helper.
-Agents and humans must use the same command path:
+For already-open ordinary Desktop sessions, the standalone helper is the
+fallback path. Agents and humans must use the same command path:
 prefer `uvx --from sim-plugin-comsol sim-comsol-attach ...` over relying
 on a PATH-installed `sim-comsol-attach.exe`. This keeps development,
 documentation, and user reproduction aligned even when Python user

--- a/src/sim_plugin_comsol/driver.py
+++ b/src/sim_plugin_comsol/driver.py
@@ -29,6 +29,7 @@ from typing import Callable, TextIO
 
 from sim.driver import ConnectionInfo, Diagnostic, LintResult, SolverInstall
 from sim.inspect import (
+    Diagnostic as RuntimeDiagnostic,
     GuiDialogProbe,
     InspectCtx,
     ScreenshotProbe,
@@ -801,6 +802,144 @@ class ComsolDriver:
             "screenshot_source": "codex-desktop-or-sim-remote",
         }
 
+    def _current_model_tag(self) -> str | None:
+        if self._model is None:
+            return None
+        try:
+            return str(self._model.tag())
+        except Exception:
+            return None
+
+    def _live_model_binding_summary(
+        self,
+        *,
+        model_tags: list[str] | None,
+        current_model_tag: str | None,
+    ) -> dict:
+        caps = self._ui_capabilities()
+        model_builder_live = bool(caps.get("model_builder_live"))
+        active_tag = self._active_model_tag
+        tags = model_tags or []
+        sidecar_tags = [tag for tag in tags if tag != active_tag]
+
+        ok = (
+            model_builder_live
+            and active_tag is not None
+            and current_model_tag == active_tag
+            and (not tags or active_tag in tags)
+        )
+        if ok:
+            message = (
+                f"Driver model handle is bound to live Desktop model "
+                f"{active_tag!r}."
+            )
+        elif not model_builder_live:
+            message = (
+                "No live Model Builder binding for this UI mode; use "
+                "visual_mode='shared-desktop' for live Desktop collaboration."
+            )
+        elif active_tag is None:
+            message = "Shared Desktop is active, but no Desktop model tag is bound."
+        elif current_model_tag != active_tag:
+            message = (
+                f"Driver model handle is {current_model_tag!r}, but the live "
+                f"Desktop active model tag is {active_tag!r}."
+            )
+        else:
+            message = (
+                f"Live Desktop active model tag {active_tag!r} was not found "
+                "in ModelUtil.tags()."
+            )
+
+        return {
+            "ok": ok,
+            "bound_model_tag": current_model_tag,
+            "model_builder_live": model_builder_live,
+            "sidecar_model_tags": sidecar_tags,
+            "message": message,
+        }
+
+    def _shared_desktop_sidecar_diagnostics(
+        self,
+        code: str,
+        *,
+        observed_model_tags: list[str] | None = None,
+    ) -> list[RuntimeDiagnostic]:
+        if self._ui_mode != "shared-desktop":
+            return []
+        if not code.strip():
+            return []
+
+        try:
+            tree = ast.parse(code)
+        except SyntaxError:
+            return []
+
+        diagnostics: list[RuntimeDiagnostic] = []
+        seen: set[tuple[str, str | None]] = set()
+        active_tag = self._active_model_tag
+        sidecar_tags = [
+            tag for tag in (observed_model_tags or [])
+            if tag != active_tag
+        ]
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if not isinstance(func, ast.Attribute):
+                continue
+            if not isinstance(func.value, ast.Name) or func.value.id != "ModelUtil":
+                continue
+            if func.attr not in {"create", "model"}:
+                continue
+
+            target_tag = None
+            if node.args and isinstance(node.args[0], ast.Constant):
+                value = node.args[0].value
+                if isinstance(value, str):
+                    target_tag = value
+
+            if func.attr == "model" and (
+                target_tag is None or target_tag == active_tag
+            ):
+                continue
+
+            key = (func.attr, target_tag)
+            if key in seen:
+                continue
+            seen.add(key)
+
+            if func.attr == "create":
+                message = (
+                    "In shared-desktop mode, ModelUtil.create(...) can create "
+                    "a server-side model that the visible COMSOL Desktop is "
+                    "not displaying. Prefer mutating the provided `model` "
+                    "handle unless a sidecar model is intentional."
+                )
+            else:
+                message = (
+                    f"In shared-desktop mode, ModelUtil.model({target_tag!r}) "
+                    f"does not match the live Desktop active model tag "
+                    f"{active_tag!r}; GUI updates may appear out of sync."
+                )
+
+            diagnostics.append(RuntimeDiagnostic(
+                severity="warning",
+                message=message,
+                source="comsol:shared-desktop",
+                code="comsol.shared_desktop.sidecar_model_risk",
+                extra={
+                    "call": f"ModelUtil.{func.attr}",
+                    "requested_tag": target_tag,
+                    "active_model_tag": active_tag,
+                    "observed_model_tags": list(observed_model_tags or []),
+                    "sidecar_model_tags": sidecar_tags,
+                },
+            ))
+
+        return diagnostics
+
     def _windows_process_rows(self) -> list[dict]:
         if os.name != "nt":
             return []
@@ -1032,6 +1171,8 @@ class ComsolDriver:
                 code = self._classify_comsol_error(str(exc))
                 message = f"ModelUtil health check failed: {exc}"
 
+        current_model_tag = self._current_model_tag()
+
         if self._model is None:
             code = "comsol.session.disconnected"
             message = "No active COMSOL model is attached"
@@ -1074,6 +1215,10 @@ class ComsolDriver:
             "modelutil_connected": modelutil_connected,
             "model_tags": model_tags,
             "active_model_tag": self._active_model_tag,
+            "live_model_binding": self._live_model_binding_summary(
+                model_tags=model_tags,
+                current_model_tag=current_model_tag,
+            ),
             "windows": self._visible_windows(),
             "last_disconnect_reason": self._last_disconnect_reason,
             "launch_options": self._launch_options,
@@ -1506,6 +1651,15 @@ class ComsolDriver:
         if namespace.get("model") is not self._model and namespace.get("model") is not None:
             self._model = namespace["model"]
 
+        observed_model_tags: list[str] | None = None
+        if self._model_util is not None:
+            try:
+                observed_model_tags = [
+                    str(tag) for tag in list(self._model_util.tags())
+                ]
+            except Exception:
+                observed_model_tags = None
+
         record = {
             "run_id": str(uuid.uuid4()),
             "ok": ok,
@@ -1544,6 +1698,10 @@ class ComsolDriver:
             extras=extras,
         )
         diags, arts = collect_diagnostics(self.probes, ctx)
+        diags.extend(self._shared_desktop_sidecar_diagnostics(
+            code,
+            observed_model_tags=observed_model_tags,
+        ))
         record["diagnostics"] = [d.to_dict() for d in diags]
         record["artifacts"] = [a.to_dict() for a in arts]
         record["health"] = self._last_health if not ok else preflight_health

--- a/tests/test_comsol_driver.py
+++ b/tests/test_comsol_driver.py
@@ -26,6 +26,53 @@ class FakeProcess:
         return self.returncode
 
 
+class FakeComsolModel:
+    def __init__(self, tag):
+        self._tag = tag
+
+    def tag(self):
+        return self._tag
+
+
+class FakeModelUtil:
+    def __init__(self):
+        self.models = {"Model1": FakeComsolModel("Model1")}
+
+    def tags(self):
+        return list(self.models)
+
+    def model(self, tag):
+        return self.models[tag]
+
+    def create(self, tag):
+        self.models[tag] = FakeComsolModel(tag)
+        return self.models[tag]
+
+
+def _shared_desktop_driver(tmp_path, monkeypatch):
+    model_util = FakeModelUtil()
+    driver = ComsolDriver()
+    driver._session_id = "s-test"
+    driver._model_util = model_util
+    driver._model = model_util.model("Model1")
+    driver._active_model_tag = "Model1"
+    driver._server_proc = FakeProcess(pid=2468, returncode=None)
+    driver._client_proc = FakeProcess(pid=1357, returncode=0)
+    driver._desktop_pid = 9753
+    driver._port = 65000
+    driver._ui_mode = "shared-desktop"
+    driver._launch_options = {
+        "requested_ui_mode": "gui",
+        "ui_mode": "shared-desktop",
+        "visual_mode": "shared-desktop",
+    }
+    driver._sim_dir = tmp_path / ".sim"
+    driver.probes = []
+    monkeypatch.setattr(driver, "_check_port", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(driver, "_visible_windows", lambda: [])
+    return driver, model_util
+
+
 class TestDetect:
     def setup_method(self):
         self.driver = ComsolDriver()
@@ -263,7 +310,7 @@ class TestLifecycleDiagnostics:
     def test_health_reports_shared_desktop_metadata(self, monkeypatch):
         driver = ComsolDriver()
         driver._session_id = "s-test"
-        driver._model = object()
+        driver._model = FakeComsolModel("Model1")
         driver._server_proc = FakeProcess(pid=2468, returncode=None)
         driver._client_proc = FakeProcess(pid=1357, returncode=0)
         driver._desktop_pid = 9753
@@ -293,7 +340,28 @@ class TestLifecycleDiagnostics:
         assert health["ui_capabilities"]["model_builder_live"] is True
         assert health["desktop_pid"] == 9753
         assert health["active_model_tag"] == "Model1"
+        assert health["live_model_binding"]["ok"] is True
+        assert health["live_model_binding"]["bound_model_tag"] == "Model1"
         assert health["windows"][0]["role"] == "desktop"
+
+    def test_health_reports_shared_desktop_sidecar_tags(self, monkeypatch):
+        driver = ComsolDriver()
+        model_util = FakeModelUtil()
+        model_util.create("SharedProbe")
+        driver._session_id = "s-test"
+        driver._model = model_util.model("Model1")
+        driver._model_util = model_util
+        driver._server_proc = FakeProcess(pid=2468, returncode=None)
+        driver._active_model_tag = "Model1"
+        driver._port = 65000
+        driver._ui_mode = "shared-desktop"
+        monkeypatch.setattr(driver, "_check_port", lambda *_args, **_kwargs: True)
+        monkeypatch.setattr(driver, "_visible_windows", lambda: [])
+
+        health = driver.health()
+
+        assert health["live_model_binding"]["ok"] is True
+        assert health["live_model_binding"]["sidecar_model_tags"] == ["SharedProbe"]
 
     def test_health_reports_attach_only_external_server(self, monkeypatch):
         driver = ComsolDriver()
@@ -359,6 +427,52 @@ class TestLifecycleDiagnostics:
         assert "shared-desktop" in modes["modes"]
         assert modes["aliases"]["no_gui"] == "no_gui"
         assert modes["aliases"]["gui"] == "server-graphics"
+
+    def test_shared_desktop_model_handle_exec_has_no_sidecar_warning(
+        self, tmp_path, monkeypatch
+    ):
+        driver, _model_util = _shared_desktop_driver(tmp_path, monkeypatch)
+
+        result = driver.run("_result = model.tag()")
+
+        assert result["ok"] is True
+        codes = [diag["code"] for diag in result["diagnostics"]]
+        assert "comsol.shared_desktop.sidecar_model_risk" not in codes
+
+    def test_shared_desktop_modelutil_create_warns_without_failing(
+        self, tmp_path, monkeypatch
+    ):
+        driver, _model_util = _shared_desktop_driver(tmp_path, monkeypatch)
+
+        result = driver.run('model = ModelUtil.create("SharedProbe")')
+
+        assert result["ok"] is True
+        warning = next(
+            diag for diag in result["diagnostics"]
+            if diag["code"] == "comsol.shared_desktop.sidecar_model_risk"
+        )
+        assert warning["severity"] == "warning"
+        assert warning["extra"]["requested_tag"] == "SharedProbe"
+
+        health = driver.health()
+        assert health["live_model_binding"]["ok"] is False
+        assert health["live_model_binding"]["bound_model_tag"] == "SharedProbe"
+
+    def test_shared_desktop_modelutil_model_non_active_warns_without_failing(
+        self, tmp_path, monkeypatch
+    ):
+        driver, model_util = _shared_desktop_driver(tmp_path, monkeypatch)
+        model_util.create("SharedProbe")
+
+        result = driver.run('model = ModelUtil.model("SharedProbe")')
+
+        assert result["ok"] is True
+        warning = next(
+            diag for diag in result["diagnostics"]
+            if diag["code"] == "comsol.shared_desktop.sidecar_model_risk"
+        )
+        assert warning["extra"]["call"] == "ModelUtil.model"
+        assert warning["extra"]["requested_tag"] == "SharedProbe"
 
 
 def _make_import_blocker(blocked: str):

--- a/uv.lock
+++ b/uv.lock
@@ -912,7 +912,7 @@ wheels = [
 
 [[package]]
 name = "sim-plugin-comsol"
-version = "0.1.10"
+version = "0.1.11"
 source = { editable = "." }
 dependencies = [
     { name = "mph" },


### PR DESCRIPTION
## Summary

- Make `shared-desktop` the documented primary path for reliable live COMSOL GUI collaboration.
- Keep Java Shell / `desktop-attach` as a fallback for already-open ordinary Desktop sessions and small human-in-the-loop edits.
- Add `session.health.live_model_binding` so agents can see whether the driver handle is bound to the Desktop active model tag.
- Warn, without failing execution, when shared-desktop snippets use `ModelUtil.create(...)` or switch to a non-active `ModelUtil.model(...)` sidecar.

## Why

Recent live testing confirmed that COMSOL client-server mode is the clean path for realtime GUI visibility, but only when agent edits target the Desktop active model tag. The plugin already supports this mode; this PR makes the guidance match that reality and adds guardrails for the sidecar-model failure mode.

## Validation

- `uv run pytest tests/test_comsol_driver.py --basetemp .pytest_tmp`
- `uv run pytest --basetemp .pytest_tmp`
- `uv run python -m compileall -q src tests`
- Manual shared-desktop smoke on COMSOL 6.4: verified `live_model_binding.ok: true`, sidecar warning for `ModelUtil.create("SharedProbe")`, and block-with-hole geometry visible in the GUI.