### PR TITLE
[codex] Add COMSOL model identity checkpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,10 @@ Use the bundled COMSOL skill in this repository. If the user wants reliable
 visible co-editing, use the sim runtime with visual_mode=shared-desktop first
 and verify session.health live_model_binding.ok. Use Java Shell Desktop attach
 only for already-open ordinary Desktop sessions, small edits, or
-human-in-the-loop fallback work. Build and solve the requested model one
-bounded step at a time.
+human-in-the-loop fallback work. For non-trivial modeling, establish the
+target model identity and working folder first: load the given .mph, or set a
+descriptive model tag/title and save an early checkpoint .mph under a case
+workdir. Build and solve the requested model one bounded step at a time.
 ```
 
 ## How it works

--- a/src/sim_plugin_comsol/_skills/comsol/SKILL.md
+++ b/src/sim_plugin_comsol/_skills/comsol/SKILL.md
@@ -225,6 +225,60 @@ These hard constraints apply to every COMSOL task through this plugin.
 
 ---
 
+## Model identity, workdir, and checkpoints
+
+For non-trivial COMSOL work, establish a durable model identity and working
+folder before building geometry, materials, physics, mesh, or studies.
+COMSOL permits untitled `Model1` scratch models, but agents need a clear
+artifact to resume from after chat compaction, process restart, server reload,
+or human handoff.
+
+Use this policy:
+
+- If the user provided an `.mph`, load that exact file and bind the session to
+  a clear model tag derived from the case name.
+- If starting from scratch in the sim runtime, pass a descriptive
+  `model_tag=<case_slug>` when connecting if the current driver supports it.
+- If starting from scratch in shared Desktop or Desktop attach mode, bind to
+  the active Desktop model first, then set a visible title/label and save it
+  early to an absolute `.mph` path.
+- Keep all related files under one working folder, for example:
+
+```text
+<workdir>/
+  model/<case_slug>.mph
+  input/
+  output/
+  scripts/
+  logs/
+```
+
+- Set `model.modelPath(...)` to the relevant `input` and `model` folders
+  when the workflow uses external files, tables, meshes, or CAD.
+- Prefer absolute paths for save/export/log targets. Do not rely on COMSOL's
+  launch directory or the Java process current directory.
+- After every major layer, save a checkpoint `.mph` or save the main `.mph`
+  after confirming the live state. Use names such as
+  `<case_slug>_01_geometry.mph`, `<case_slug>_02_materials.mph`, and
+  `<case_slug>_03_solved.mph` when intermediate files help review or resume.
+- Before resuming a partially completed task, inspect identity first:
+
+```bash
+sim inspect session.health
+sim inspect comsol.model.identity
+sim inspect comsol.model.describe_text
+```
+
+Treat `comsol.model.identity.checkpoint_ready=false`, missing
+`file_path`/`location`, or a bound tag that does not match `active_model_tag`
+as a pause-and-repair condition before doing new modeling work.
+
+Scratch probes and one-off API experiments may stay as `Model1` or
+`Untitled.mph`, but label them as disposable in the agent's status and do not
+mix them with user-facing engineering artifacts.
+
+---
+
 ## Required protocol
 
 Treat COMSOL as a live engineering state, not as a one-shot code generator.
@@ -250,15 +304,21 @@ visible model coherent after every step.
    ready.
 3. For sim runtime, run `sim check comsol`, connect if needed, and read
    `session.versions` plus `sim inspect session.health`.
-4. Inspect the baseline state. In Desktop attach, use the visible Model
+4. Establish or verify model identity, working folder, and checkpoint target.
+   For sim runtime, inspect `comsol.model.identity` when available. For
+   Desktop attach, probe the visible model title/file path through Java Shell
+   or the Desktop UI before mutating serious work.
+5. Inspect the baseline state. In Desktop attach, use the visible Model
    Builder, Graphics view, tables, and Java Shell output. In sim runtime, use
    `sim inspect comsol.model.describe_text` when available.
-5. Execute one bounded modeling step.
-6. Inspect the result before continuing: visible Desktop state for attach;
+6. Execute one bounded modeling step.
+7. Inspect the result before continuing: visible Desktop state for attach;
    `sim inspect last.result`, `comsol.model.describe_text`, and
    `comsol.node.properties:<tag-or-dot-path>` for sim runtime.
-7. Continue only after the live model matches the intended geometry,
-   materials, physics, mesh, study, and result state.
+8. Save or update the relevant checkpoint after each passed major layer.
+9. Continue only after the live model matches the intended geometry,
+   materials, physics, mesh, study, and result state and the checkpoint can be
+   used to resume.
 
 For simple known-good smoke coverage, use the numbered snippets under
 `base/workflows/`. For realistic engineering examples, use project-local

--- a/src/sim_plugin_comsol/_skills/comsol/base/reference/runtime_introspection.md
+++ b/src/sim_plugin_comsol/_skills/comsol/base/reference/runtime_introspection.md
@@ -12,6 +12,7 @@ model edit:
 
 ```bash
 sim inspect session.health
+sim inspect comsol.model.identity
 sim inspect last.result
 sim inspect comsol.model.describe_text
 sim inspect comsol.model.describe
@@ -23,6 +24,7 @@ Target meanings:
 | Target | Use |
 |---|---|
 | `session.health` | Check solver process, UI mode, COMSOL version, PIDs, logs, and whether a visible desktop is live. |
+| `comsol.model.identity` | Check active/bound model tag, title/label, saved file path or database location, model path, read-only state, and whether the session has enough durable identity to resume. |
 | `last.result` | Check the last `sim exec` result, artifacts, probes, diagnostics, and exceptions. |
 | `comsol.model.describe_text` | Human-readable summary of components, physics, features, properties, and warnings. |
 | `comsol.model.describe` | Structured summary for programmatic comparison. |
@@ -52,6 +54,7 @@ Inspect after each layer:
 
 | Layer | Check |
 |---|---|
+| Identity | Active model tag, bound model tag, model title/label, saved `.mph` or database location, model path, and intended working folder. |
 | Geometry | Component, geometry sequence, named selections, domain/boundary counts where available. |
 | Materials | Material tags, material selections, key material property groups. |
 | Physics | Physics interface tags, feature tags, feature types, non-empty selections. |

--- a/src/sim_plugin_comsol/_skills/comsol/base/workflows/debug_failed_exec.md
+++ b/src/sim_plugin_comsol/_skills/comsol/base/workflows/debug_failed_exec.md
@@ -8,6 +8,7 @@ failure and the live model state, then retry with the smallest patch.
 1. Inspect the structured result:
 
    ```bash
+   sim inspect comsol.model.identity
    sim inspect last.result
    ```
 
@@ -69,6 +70,8 @@ except Exception as exc:
 ## Good repair behavior
 
 - Keep the current session unless it is corrupted.
+- If identity is missing or not checkpoint-ready, save or load a durable
+  `.mph` before further risky edits.
 - Save a `.mph` checkpoint before risky rebuilds.
 - Prefer checking parent tags over guessing child tags.
 - Prefer inspecting a node over trying alternate property names.

--- a/src/sim_plugin_comsol/_skills/comsol/base/workflows/model_review_loop.md
+++ b/src/sim_plugin_comsol/_skills/comsol/base/workflows/model_review_loop.md
@@ -6,20 +6,24 @@ or physics mistake created many steps earlier.
 
 ## Loop
 
+0. Establish or verify model identity, workdir, and checkpoint target.
 1. Execute one bounded modeling step.
 2. Inspect `sim inspect last.result`.
-3. Inspect the live model with `sim inspect comsol.model.describe_text`
+3. Inspect `sim inspect comsol.model.identity` when available.
+4. Inspect the live model with `sim inspect comsol.model.describe_text`
    when available.
-4. Inspect suspicious nodes with
+5. Inspect suspicious nodes with
    `sim inspect comsol.node.properties:<tag-or-dot-path>` or a raw Java
    fallback snippet.
-5. Compare the live model to the intended state below.
-6. Continue only after the checkpoint passes.
+6. Compare the live model to the intended state below.
+7. Save or update the checkpoint `.mph` after each passed major layer.
+8. Continue only after the checkpoint passes.
 
 ## Checkpoints
 
 | Layer | Expected evidence |
 |---|---|
+| Identity | Active model tag and bound model tag are known; model has a title/label; serious work has a saved `.mph` or database location; `model.modelPath(...)` includes needed input/model folders; the working folder contains related inputs, scripts, outputs, and logs. |
 | Geometry | Expected component exists; geometry sequence has expected features; named selections exist for later physics; saved `.mph` artifact opens if Desktop review is needed. |
 | Materials | Material tags exist; each material has a non-empty domain selection; critical property groups are present. |
 | Physics | Physics interfaces exist; required domain and boundary features exist; feature selections are non-empty and match the intended entity dimension. |

--- a/src/sim_plugin_comsol/driver.py
+++ b/src/sim_plugin_comsol/driver.py
@@ -1226,9 +1226,95 @@ class ComsolDriver:
         self._last_health = health
         return health
 
+    def _model_identity(self) -> dict:
+        """Return human/workflow identity for the bound COMSOL model.
+
+        This target is intentionally separate from session health. Health says
+        whether the server/session is alive; identity says what engineering
+        artifact the agent is currently mutating and whether it has a durable
+        save location.
+        """
+        current_model_tag = self._current_model_tag()
+        if self._model is None:
+            health = self.health()
+            return {
+                "ok": False,
+                "connected": False,
+                "code": health.get("code", "comsol.session.disconnected"),
+                "message": health.get("message", "COMSOL session is not connected"),
+                "active_model_tag": self._active_model_tag,
+                "bound_model_tag": current_model_tag,
+            }
+
+        def _call(method_name: str):
+            method = getattr(self._model, method_name, None)
+            if not callable(method):
+                return None
+            try:
+                return method()
+            except Exception as exc:  # noqa: BLE001 - Java exceptions vary by version
+                return {"error": type(exc).__name__, "message": str(exc)}
+
+        def _has_value(value: object) -> bool:
+            return value is not None and not isinstance(value, dict) and bool(str(value))
+
+        model_tags: list[str] | None = None
+        models_used_by_other_clients: list[str] | None = None
+        if self._model_util is not None:
+            try:
+                model_tags = [str(tag) for tag in list(self._model_util.tags())]
+            except Exception:  # noqa: BLE001 - best-effort identity target
+                model_tags = None
+            used_method = getattr(self._model_util, "modelsUsedByOtherClients", None)
+            if callable(used_method):
+                try:
+                    models_used_by_other_clients = [
+                        str(tag) for tag in list(used_method())
+                    ]
+                except Exception:  # noqa: BLE001 - best-effort identity target
+                    models_used_by_other_clients = None
+
+        workdir = getattr(self, "_workdir", None)
+        sim_dir = getattr(self, "_sim_dir", None)
+        identity = {
+            "ok": True,
+            "connected": True,
+            "active_model_tag": self._active_model_tag,
+            "bound_model_tag": current_model_tag,
+            "model_tags": model_tags,
+            "models_used_by_other_clients": models_used_by_other_clients,
+            "title": _call("title"),
+            "label": _call("label"),
+            "file_path": _call("getFilePath"),
+            "location": _call("location"),
+            "location_uri": _call("locationUri"),
+            "model_path": _call("modelPath"),
+            "read_only": _call("isReadOnly"),
+            "workdir": str(workdir) if workdir else None,
+            "sim_dir": str(sim_dir) if sim_dir else None,
+        }
+        identity["has_saved_location"] = bool(
+            _has_value(identity.get("file_path"))
+            or _has_value(identity.get("location"))
+        )
+        identity["has_model_path"] = _has_value(identity.get("model_path"))
+        identity["checkpoint_ready"] = bool(
+            identity["active_model_tag"]
+            and identity["bound_model_tag"]
+            and identity["active_model_tag"] == identity["bound_model_tag"]
+            and identity["has_saved_location"]
+        )
+        return identity
+
     def query(self, name: str) -> dict:
         if name in {"health", "session.health"}:
             return self.health()
+        if name in {
+            "model.identity",
+            "comsol.model.identity",
+            "session.model_identity",
+        }:
+            return self._model_identity()
         if name in {"ui.modes", "session.ui_modes"}:
             return {
                 "ok": True,

--- a/tests/test_comsol_driver.py
+++ b/tests/test_comsol_driver.py
@@ -29,9 +29,37 @@ class FakeProcess:
 class FakeComsolModel:
     def __init__(self, tag):
         self._tag = tag
+        self._title = "Checkpoint Model"
+        self._label = "Checkpoint Model"
+        self._file_path = r"C:\work\checkpoint_model\model\checkpoint_model.mph"
+        self._location = self._file_path
+        self._location_uri = None
+        self._model_path = r"C:\work\checkpoint_model\input;C:\work\checkpoint_model\model"
+        self._read_only = False
 
     def tag(self):
         return self._tag
+
+    def title(self):
+        return self._title
+
+    def label(self):
+        return self._label
+
+    def getFilePath(self):
+        return self._file_path
+
+    def location(self):
+        return self._location
+
+    def locationUri(self):
+        return self._location_uri
+
+    def modelPath(self):
+        return self._model_path
+
+    def isReadOnly(self):
+        return self._read_only
 
 
 class FakeModelUtil:
@@ -47,6 +75,9 @@ class FakeModelUtil:
     def create(self, tag):
         self.models[tag] = FakeComsolModel(tag)
         return self.models[tag]
+
+    def modelsUsedByOtherClients(self):
+        return []
 
 
 def _shared_desktop_driver(tmp_path, monkeypatch):
@@ -415,6 +446,28 @@ class TestLifecycleDiagnostics:
         assert health["ok"] is False
         assert health["connected"] is False
         assert health["code"] == "comsol.session.disconnected"
+
+    def test_query_model_identity_disconnected(self):
+        driver = ComsolDriver()
+
+        identity = driver.query("comsol.model.identity")
+
+        assert identity["ok"] is False
+        assert identity["connected"] is False
+        assert identity["code"] == "comsol.session.disconnected"
+
+    def test_query_model_identity_connected(self, tmp_path, monkeypatch):
+        driver, _model_util = _shared_desktop_driver(tmp_path, monkeypatch)
+
+        identity = driver.query("comsol.model.identity")
+
+        assert identity["ok"] is True
+        assert identity["active_model_tag"] == "Model1"
+        assert identity["bound_model_tag"] == "Model1"
+        assert identity["title"] == "Checkpoint Model"
+        assert identity["has_saved_location"] is True
+        assert identity["has_model_path"] is True
+        assert identity["checkpoint_ready"] is True
 
     def test_query_ui_modes(self):
         driver = ComsolDriver()


### PR DESCRIPTION
## Summary

- Add a `comsol.model.identity` inspect target so agents can see the active/bound model tag, title/label, saved path/location, model path, and checkpoint readiness before mutating or resuming COMSOL work.
- Update the bundled COMSOL skill, review loop, debug loop, and README to require durable model identity, a case workdir, and checkpoint `.mph` artifacts for non-trivial work.
- Keep `Model1`/untitled models acceptable only for disposable probes while making real agent workflows resumable after process restarts, server reloads, or chat handoff.

## Why

Agents were often continuing in an unspecified COMSOL model. COMSOL allows this for interactive scratch work, but it is fragile for autonomous engineering workflows because state can be unsaved, attached to the wrong tag, or hard to resume.

## Validation

- `uv run pytest tests/test_comsol_driver.py -q --basetemp .pytest_tmp\comsol_identity`

Note: a plain pytest run hit the known Windows temp permission issue for `AppData\Local\Temp\pytest-of-jiwei`, so the documented repo-local basetemp workaround was used.