### PR TITLE
[codex] Add COMSOL live inspect targets

### DIFF
--- a/src/sim_plugin_comsol/driver.py
+++ b/src/sim_plugin_comsol/driver.py
@@ -25,7 +25,7 @@ import traceback
 import uuid
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
-from typing import Callable, TextIO
+from typing import Any, Callable, TextIO
 
 from sim.driver import ConnectionInfo, Diagnostic, LintResult, SolverInstall
 from sim.inspect import (
@@ -1306,6 +1306,271 @@ class ComsolDriver:
         )
         return identity
 
+    def _disconnected_query_result(self, target: str) -> dict:
+        health = self.health()
+        return {
+            "ok": False,
+            "connected": False,
+            "target": target,
+            "code": health.get("code", "comsol.session.disconnected"),
+            "message": health.get("message", "COMSOL session is not connected"),
+        }
+
+    def _model_describe(self, *, text: bool = False) -> dict:
+        if self._model is None:
+            return self._disconnected_query_result(
+                "comsol.model.describe_text" if text else "comsol.model.describe"
+            )
+        try:
+            from .lib import describe, format_text
+
+            summary = describe(self._model)
+            warnings = [
+                (
+                    "Live model describe currently covers physics interfaces and "
+                    "their features; inspect other layers with targeted node "
+                    "properties or read-only sim exec probes."
+                )
+            ]
+            if text:
+                return {
+                    "ok": True,
+                    "target": "comsol.model.describe_text",
+                    "text": format_text(summary),
+                    "summary": summary,
+                    "partial": True,
+                    "warnings": warnings,
+                }
+            return {
+                "ok": True,
+                "target": "comsol.model.describe",
+                **summary,
+                "partial": True,
+                "warnings": warnings,
+            }
+        except Exception as exc:  # noqa: BLE001 - Java APIs vary by COMSOL version
+            return {
+                "ok": False,
+                "target": "comsol.model.describe_text" if text else "comsol.model.describe",
+                "code": "comsol.model.describe_failed",
+                "error": str(exc),
+                "exception_type": type(exc).__name__,
+            }
+
+    @staticmethod
+    def _call_node_method(node: Any, method_name: str, *args: Any) -> Any:
+        method = getattr(node, method_name, None)
+        if not callable(method):
+            raise AttributeError(f"{type(node).__name__} has no callable {method_name}()")
+        return method(*args)
+
+    @staticmethod
+    def _node_tags(container: Any) -> list[str]:
+        return [str(tag) for tag in list(container.tags())]
+
+    def _resolve_node_path(self, target: str) -> Any:
+        if self._model is None:
+            raise RuntimeError("COMSOL session is not connected")
+
+        cleaned = target.strip()
+        if not cleaned:
+            raise ValueError("missing node target after comsol.node.properties:")
+
+        # Allow either dot or colon separators in driver-specific inspect names.
+        tokens = [
+            piece for piece in re.split(r"[.:]+", cleaned)
+            if piece and piece not in {"model", "root"}
+        ]
+        if not tokens:
+            raise ValueError(f"invalid node target: {target!r}")
+        if len(tokens) == 1:
+            return self._find_node_by_tag(tokens[0])
+
+        aliases = {
+            "comp": "component",
+            "components": "component",
+            "geometry": "geom",
+            "geometries": "geom",
+            "materials": "material",
+            "physicses": "physics",
+            "features": "feature",
+            "meshes": "mesh",
+            "studies": "study",
+            "results": "result",
+            "selections": "selection",
+            "variables": "variable",
+            "functions": "func",
+            "property_group": "propertyGroup",
+            "propertygroup": "propertyGroup",
+            "propertygroups": "propertyGroup",
+            "datasets": "dataset",
+            "numericals": "numerical",
+        }
+        child_methods = {
+            "component",
+            "geom",
+            "physics",
+            "feature",
+            "material",
+            "mesh",
+            "study",
+            "result",
+            "selection",
+            "variable",
+            "func",
+            "propertyGroup",
+            "dataset",
+            "numerical",
+            "view",
+            "param",
+        }
+
+        node: Any = self._model
+        index = 0
+        while index < len(tokens):
+            raw_method = tokens[index]
+            method_name = aliases.get(raw_method.lower(), raw_method)
+            if method_name not in child_methods:
+                raise ValueError(
+                    f"expected a COMSOL child method at {raw_method!r} in {target!r}"
+                )
+            tag: str | None = None
+            if index + 1 < len(tokens):
+                candidate = tokens[index + 1]
+                candidate_method = aliases.get(candidate.lower(), candidate)
+                if candidate_method not in child_methods:
+                    tag = candidate
+                    index += 1
+            node = (
+                self._call_node_method(node, method_name, tag)
+                if tag is not None
+                else self._call_node_method(node, method_name)
+            )
+            index += 1
+        return node
+
+    def _find_node_by_tag(self, tag: str) -> Any:
+        if self._model is None:
+            raise RuntimeError("COMSOL session is not connected")
+
+        visited: set[int] = set()
+        child_scopes = (
+            "component",
+            "geom",
+            "physics",
+            "feature",
+            "material",
+            "mesh",
+            "study",
+            "result",
+            "selection",
+            "propertyGroup",
+            "dataset",
+            "numerical",
+        )
+
+        def visit(node: Any, scopes: tuple[str, ...]) -> Any | None:
+            try:
+                marker = id(node)
+            except Exception:
+                marker = 0
+            if marker in visited:
+                return None
+            visited.add(marker)
+
+            if self._safe_node_string(node, "tag") == tag:
+                return node
+
+            for scope in scopes:
+                try:
+                    list_method = getattr(node, scope, None)
+                    if not callable(list_method):
+                        continue
+                    child_container = list_method()
+                except Exception:
+                    continue
+                try:
+                    child_tags = self._node_tags(child_container)
+                except Exception:
+                    child_tags = []
+                for child_tag in child_tags:
+                    try:
+                        child = list_method(child_tag)
+                    except Exception:
+                        continue
+                    if child_tag == tag:
+                        return child
+                    found = visit(
+                        child,
+                        child_scopes,
+                    )
+                    if found is not None:
+                        return found
+            return None
+
+        found = visit(
+            self._model,
+            child_scopes + ("param",),
+        )
+        if found is None:
+            raise KeyError(f"could not resolve COMSOL node tag {tag!r}")
+        return found
+
+    @staticmethod
+    def _safe_node_string(node: Any, method_name: str) -> str | None:
+        method = getattr(node, method_name, None)
+        if not callable(method):
+            return None
+        try:
+            return str(method())
+        except Exception:
+            return None
+
+    @staticmethod
+    def _read_node_properties(node: Any) -> tuple[list[str], dict[str, str], list[dict]]:
+        names = [str(name) for name in list(node.properties())]
+        values: dict[str, str] = {}
+        warnings: list[dict] = []
+        for name in names:
+            try:
+                values[name] = str(node.getString(name))
+            except Exception as exc:  # noqa: BLE001 - COMSOL property readers vary
+                warnings.append({
+                    "property": name,
+                    "code": "comsol.node.property_value_unreadable",
+                    "exception_type": type(exc).__name__,
+                    "message": str(exc),
+                })
+        return names, values, warnings
+
+    def _node_properties(self, target: str) -> dict:
+        if self._model is None:
+            return self._disconnected_query_result("comsol.node.properties")
+        try:
+            node = self._resolve_node_path(target)
+            names, values, warnings = self._read_node_properties(node)
+            return {
+                "ok": True,
+                "target": "comsol.node.properties",
+                "node": target,
+                "type": self._safe_node_string(node, "getType"),
+                "name": self._safe_node_string(node, "name"),
+                "tag": self._safe_node_string(node, "tag"),
+                "properties": names,
+                "property_values": values,
+                "warnings": warnings,
+                "partial": bool(warnings),
+            }
+        except Exception as exc:  # noqa: BLE001 - Java exceptions vary
+            return {
+                "ok": False,
+                "target": "comsol.node.properties",
+                "node": target,
+                "code": "comsol.node.properties_failed",
+                "error": str(exc),
+                "exception_type": type(exc).__name__,
+            }
+
     def query(self, name: str) -> dict:
         if name in {"health", "session.health"}:
             return self.health()
@@ -1337,6 +1602,13 @@ class ComsolDriver:
                 },
                 "aliases": dict(_COMSOL_UI_MODE_ALIASES),
             }
+        if name in {"model.describe", "comsol.model.describe"}:
+            return self._model_describe(text=False)
+        if name in {"model.describe_text", "comsol.model.describe_text"}:
+            return self._model_describe(text=True)
+        for prefix in ("node.properties:", "comsol.node.properties:"):
+            if name.startswith(prefix):
+                return self._node_properties(name[len(prefix):])
         return {"ok": False, "error": f"unknown inspect target: {name}"}
 
     def _check_port(self, port: int, timeout: float = 2) -> bool:

--- a/tests/test_comsol_driver.py
+++ b/tests/test_comsol_driver.py
@@ -26,6 +26,107 @@ class FakeProcess:
         return self.returncode
 
 
+class FakeSelection:
+    def __init__(self, entities=None, named=""):
+        self._entities = list(entities or [])
+        self._named = named
+
+    def entities(self):
+        return list(self._entities)
+
+    def named(self):
+        return self._named
+
+
+class FakeNodeSet:
+    def __init__(self, nodes):
+        self._nodes = {node.tag(): node for node in nodes}
+
+    def tags(self):
+        return list(self._nodes)
+
+    def __call__(self, tag=None):
+        if tag is None:
+            return self
+        return self._nodes[tag]
+
+
+class FakeFeature:
+    def __init__(self, tag, ftype, name, properties=None, entities=None):
+        self._tag = tag
+        self._type = ftype
+        self._name = name
+        self._properties = dict(properties or {})
+        self._selection = FakeSelection(entities or [])
+
+    def tag(self):
+        return self._tag
+
+    def getType(self):
+        return self._type
+
+    def name(self):
+        return self._name
+
+    def selection(self):
+        return self._selection
+
+    def properties(self):
+        return list(self._properties)
+
+    def getString(self, name):
+        if name not in self._properties:
+            raise KeyError(name)
+        return self._properties[name]
+
+
+class FakePhysics:
+    def __init__(self, tag, ptype, name, features):
+        self._tag = tag
+        self._type = ptype
+        self._name = name
+        self._features = FakeNodeSet(features)
+
+    def tag(self):
+        return self._tag
+
+    def getType(self):
+        return self._type
+
+    def name(self):
+        return self._name
+
+    def feature(self, tag=None):
+        return self._features(tag)
+
+
+class FakeComponent:
+    def __init__(self, tag):
+        self._tag = tag
+        self._physics = FakeNodeSet([
+            FakePhysics(
+                "ht",
+                "HeatTransfer",
+                "Heat Transfer in Solids",
+                [
+                    FakeFeature(
+                        "temp1",
+                        "TemperatureBoundary",
+                        "Temperature 1",
+                        properties={"T0": "373[K]", "T0_src": "userdef"},
+                        entities=[1],
+                    ),
+                ],
+            )
+        ])
+
+    def tag(self):
+        return self._tag
+
+    def physics(self, tag=None):
+        return self._physics(tag)
+
+
 class FakeComsolModel:
     def __init__(self, tag):
         self._tag = tag
@@ -36,6 +137,7 @@ class FakeComsolModel:
         self._location_uri = None
         self._model_path = r"C:\work\checkpoint_model\input;C:\work\checkpoint_model\model"
         self._read_only = False
+        self._components = FakeNodeSet([FakeComponent("comp1")])
 
     def tag(self):
         return self._tag
@@ -60,6 +162,12 @@ class FakeComsolModel:
 
     def isReadOnly(self):
         return self._read_only
+
+    def component(self, tag=None):
+        return self._components(tag)
+
+    def physics(self, tag=None):
+        return self.component("comp1").physics(tag)
 
 
 class FakeModelUtil:
@@ -468,6 +576,65 @@ class TestLifecycleDiagnostics:
         assert identity["has_saved_location"] is True
         assert identity["has_model_path"] is True
         assert identity["checkpoint_ready"] is True
+
+    def test_query_model_describe_disconnected(self):
+        driver = ComsolDriver()
+
+        result = driver.query("comsol.model.describe")
+
+        assert result["ok"] is False
+        assert result["code"] == "comsol.session.disconnected"
+
+    def test_query_model_describe_connected(self, tmp_path, monkeypatch):
+        driver, _model_util = _shared_desktop_driver(tmp_path, monkeypatch)
+
+        result = driver.query("comsol.model.describe")
+
+        assert result["ok"] is True
+        assert result["what"] == "physics"
+        assert result["partial"] is True
+        assert result["physics"][0]["tag"] == "ht"
+        assert result["physics"][0]["features"][0]["tag"] == "temp1"
+
+    def test_query_model_describe_text_connected(self, tmp_path, monkeypatch):
+        driver, _model_util = _shared_desktop_driver(tmp_path, monkeypatch)
+
+        result = driver.query("comsol.model.describe_text")
+
+        assert result["ok"] is True
+        assert "TemperatureBoundary" in result["text"]
+        assert "T0=373[K]" in result["text"]
+        assert result["summary"]["what"] == "physics"
+
+    def test_query_node_properties_by_dot_path(self, tmp_path, monkeypatch):
+        driver, _model_util = _shared_desktop_driver(tmp_path, monkeypatch)
+
+        result = driver.query(
+            "comsol.node.properties:component.comp1.physics.ht.feature.temp1"
+        )
+
+        assert result["ok"] is True
+        assert result["type"] == "TemperatureBoundary"
+        assert result["name"] == "Temperature 1"
+        assert result["properties"] == ["T0", "T0_src"]
+        assert result["property_values"]["T0"] == "373[K]"
+
+    def test_query_node_properties_by_tag(self, tmp_path, monkeypatch):
+        driver, _model_util = _shared_desktop_driver(tmp_path, monkeypatch)
+
+        result = driver.query("comsol.node.properties:temp1")
+
+        assert result["ok"] is True
+        assert result["tag"] == "temp1"
+        assert result["property_values"]["T0_src"] == "userdef"
+
+    def test_query_node_properties_unknown_node(self, tmp_path, monkeypatch):
+        driver, _model_util = _shared_desktop_driver(tmp_path, monkeypatch)
+
+        result = driver.query("comsol.node.properties:missing_feature")
+
+        assert result["ok"] is False
+        assert result["code"] == "comsol.node.properties_failed"
 
     def test_query_ui_modes(self):
         driver = ComsolDriver()


### PR DESCRIPTION
## Summary

- Wire `comsol.model.describe`, `comsol.model.describe_text`, and `comsol.node.properties:<target>` through `ComsolDriver.query()`.
- Reuse the existing live-model `describe()` / `format_text()` helpers and mark the describe output `partial=true` because the helper currently covers physics interfaces and features.
- Add focused node-property lookup for both explicit dot paths, such as `component.comp1.physics.ht.feature.temp1`, and tag-only lookups, such as `temp1`.
- Extend driver unit tests with a fake component/physics/feature tree for the three inspect targets.

Refs svd-ai-lab/sim-proj#141.

## Why

The bundled COMSOL skill already told agents to use these inspect targets, but the driver only exposed `session.health`, `comsol.model.identity`, and `ui.modes`. Agents following the skill would hit `unknown inspect target` and fall back to manual read-only snippets. This PR closes that driver/skill contract gap.

## Validation

- `uv run pytest tests/test_comsol_driver.py -q --basetemp .pytest_basetemp/comsol_query_targets` -> 42 passed
- `uv run pytest tests -q --basetemp .pytest_basetemp/all` -> 110 passed, 1 skipped
- `uv run sim --json check comsol` -> detected COMSOL 6.4.0.293 at `C:\Program Files\COMSOL\COMSOL64\Multiphysics`, profile `comsol_64_mph_1`
- Live CLI e2e:
  - `uv run sim --json connect --solver comsol --ui-mode no_gui`
  - `uv run sim --json exec --file src\sim_plugin_comsol\_skills\comsol\base\workflows\block_with_hole\00_create_geometry.py --label live-query-geometry`
  - `uv run sim --json exec --file src\sim_plugin_comsol\_skills\comsol\base\workflows\block_with_hole\02_setup_physics.py --label live-query-physics`
  - `uv run sim --json inspect comsol.model.describe` -> returned `ok=true`, `what=physics`, `ht` features including `temp1`
  - `uv run sim --json inspect comsol.model.describe_text` -> returned text including `TemperatureBoundary` and `T0=373[K]`
  - `uv run sim --json inspect 'comsol.node.properties:component.comp1.physics.ht.feature.temp1'` -> returned `T0=373[K]`
  - `uv run sim --json inspect 'comsol.node.properties:temp1'` -> returned `T0=373[K]`
- Direct shared-desktop smoke: `ComsolDriver().launch(ui_mode="gui", visual_mode="shared-desktop", desktop_timeout=90)` -> `effective_ui_mode=shared-desktop`, `model_builder_live=true`, `live_model_binding.ok=true`, `comsol.model.identity.ok=true`, `comsol.model.describe.ok=true`
- `git diff --check` -> clean apart from Windows CRLF conversion warnings
