### PR TITLE
[codex] Hide Desktop attach from main COMSOL guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,16 @@ Use Codex, Claude Code, or another AI agent to work with
 already use.
 
 `sim-plugin-comsol` gives an agent practical COMSOL control paths: inspect
-saved `.mph` files, attach to a visible COMSOL Desktop session, build or modify
-models through the COMSOL Java API, run studies, check live-session health, and
-export results while the engineer can keep watching or intervening in COMSOL
-Desktop.
+saved `.mph` files, build or modify models through the COMSOL Java API, run
+studies, check live-session health, and work through a shared visible COMSOL
+Desktop session when the engineer wants to watch or intervene.
 
 COMSOL itself and its `mph` Python binding are not bundled. See
 [LICENSE-NOTICE.md](LICENSE-NOTICE.md).
 
 ## What an agent can do with COMSOL
 
-- Help with a model you already have open in COMSOL Desktop.
+- Load and modify existing COMSOL `.mph` models.
 - Build and solve a model step by step while you watch the Model Builder.
 - Inspect a saved `.mph` file before deciding what to change.
 - Run bounded edits, checks, plots, and result-export steps through COMSOL's
@@ -23,9 +22,9 @@ COMSOL itself and its `mph` Python binding are not bundled. See
 - Keep a structured audit trail of commands, health checks, and generated
   artifacts so results can be reviewed rather than guessed.
 
-This repository is intended to be the complete COMSOL agent bundle: driver,
-Desktop attach helper, and bundled COMSOL skill. A receiving agent should not
-need a separate COMSOL skill checkout.
+This repository is intended to be the complete COMSOL agent bundle: driver and
+bundled COMSOL skill. A receiving agent should not need a separate COMSOL skill
+checkout.
 
 ## Choose the right COMSOL workflow
 
@@ -49,25 +48,7 @@ view of agent edits.
 Prefer this path for reliable multi-step model building, solving, structured
 inspection, and repeatable agent workflows.
 
-### 2. User-owned Desktop attach — best for small visible edits
-
-Use this when the user already opened COMSOL Desktop normally, loaded their
-`.mph`, opened Java Shell, and wants an agent to make a small visible edit or
-run a quick human-in-the-loop check inside that same Desktop window:
-
-```powershell
-sim-comsol-attach open --json --timeout 120
-sim-comsol-attach health --json
-sim-comsol-attach exec --file step.java --json
-```
-
-The Desktop attach helper submits COMSOL Java Shell text to the visible user
-session. It is intentionally conservative: it should help with bounded edits
-and quick checks, but it should not be treated as proof that a full solve or
-long workflow succeeded unless the agent verifies the resulting COMSOL state or
-artifacts.
-
-### 3. Saved `.mph` inspection — best before changing a file
+### 2. Saved `.mph` inspection — best before changing a file
 
 When the user only needs to know what is in a saved COMSOL model, use the
 bundled offline inspection helpers before launching a heavyweight COMSOL
@@ -104,16 +85,14 @@ is about COMSOL:
 
 ```text
 Use the bundled COMSOL skill from sim-plugin-comsol. First identify whether the
-user wants: (1) a reliable agent-owned shared Desktop session, (2) a small edit
-inside an already-open COMSOL Desktop via Java Shell attach, or (3) offline
+user wants: (1) a reliable agent-owned shared Desktop session or (2) offline
 inspection of a saved .mph file. For reliable visible co-editing, use
 `sim connect --solver comsol --ui-mode gui --driver-option visual_mode=shared-desktop`
-and verify `session.health.live_model_binding.ok`. Use Java Shell Desktop
-attach only for already-open ordinary Desktop sessions, small edits, or
-human-in-the-loop fallback work. For non-trivial modeling, establish the target
-model identity and working folder first: load the given .mph, or set a
-descriptive model tag/title and save an early checkpoint .mph under a case
-workdir. Build and solve the requested model one bounded step at a time.
+and verify `session.health.live_model_binding.ok`. For non-trivial modeling,
+establish the target model identity and working folder first: load the given
+.mph, or set a descriptive model tag/title and save an early checkpoint .mph
+under a case workdir. Build and solve the requested model one bounded step at a
+time.
 ```
 
 The bundled skill entry point is:
@@ -127,10 +106,9 @@ src/sim_plugin_comsol/_skills/comsol/SKILL.md
 `sim-plugin-comsol` is a Python package that extends
 [sim-cli](https://github.com/svd-ai-lab/sim-cli). sim-cli provides the common
 agent runtime surface (`connect`, `exec`, `inspect`, `screenshot`, `run`), while
-this plugin supplies the COMSOL-specific driver, Desktop attach command, and
-COMSOL agent skill.
+this plugin supplies the COMSOL-specific driver and COMSOL agent skill.
 
-The plugin registers the Desktop attach CLI plus three entry-point groups:
+The plugin registers three entry-point groups:
 
 ```toml
 [project.entry-points."sim.drivers"]
@@ -141,14 +119,11 @@ comsol = "sim_plugin_comsol:skills_dir"
 
 [project.entry-points."sim.plugins"]
 comsol = "sim_plugin_comsol:plugin_info"
-
-[project.scripts]
-sim-comsol-attach = "sim_plugin_comsol.desktop_attach.cli:main"
 ```
 
 `sim.drivers` exposes the driver class; `sim.skills` exposes a directory of
 skill files bundled inside the wheel; `sim.plugins` exposes plugin metadata for
-discovery. `sim-comsol-attach` exposes the Desktop-first collaboration path.
+discovery.
 
 ## Develop
 

--- a/src/sim_plugin_comsol/_skills/comsol/SKILL.md
+++ b/src/sim_plugin_comsol/_skills/comsol/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: comsol-sim
-description: Use when working with COMSOL Multiphysics through the sim runtime, shared-desktop client-server GUI collaboration, a fallback Desktop attach workflow, or saved `.mph` artifacts — building/debugging/solving stateful COMSOL models through the JPype Java API when structured runtime inspection is needed, controlling an already-open ordinary Desktop through Java Shell for small human-in-the-loop edits, and performing offline `.mph` introspection without a JVM.
+description: Use when working with COMSOL Multiphysics through the sim runtime, shared-desktop client-server GUI collaboration, or saved `.mph` artifacts — building/debugging/solving stateful COMSOL models through the JPype Java API when structured runtime inspection is needed, and performing offline `.mph` introspection without a JVM. Includes a fragile Java Shell Desktop attach fallback only for explicit small edits in an already-open ordinary Desktop session.
 ---
 
 # comsol-sim
 
 This file is the **COMSOL Multiphysics** index. Use the sim runtime/JPype path
 for serious model building, solving, inspection, saved `.mph` artifacts, and
-reliable live GUI collaboration through `visual_mode=shared-desktop`. Use
-Desktop attach as a fallback for small user-visible edits in an already-open
-ordinary COMSOL Desktop, quick visual checks, or human-in-the-loop
-interventions. Use the offline `.mph` inspection path for saved artifacts when
-no live COMSOL session is needed.
+reliable live GUI collaboration through `visual_mode=shared-desktop`. Treat
+Desktop attach as a fragile UIA fallback, not a normal routing option: use it
+only when the user explicitly needs a small edit inside an already-open
+ordinary COMSOL Desktop and reconnecting through `mphclient` is not acceptable.
+Use the offline `.mph` inspection path for saved artifacts when no live COMSOL
+session is needed.
 
 This skill is self-contained for COMSOL work. Do not require a separate skill
 checkout or an external sim-cli skill. Use this file for the COMSOL workflow,
@@ -25,8 +26,8 @@ Choose the control path first:
 
 | Path | Use it for | Avoid it for |
 |---|---|---|
-| sim runtime / JPype | Building, solving, inspecting, debugging, saving `.mph`, repeatable case generation, and reliable live GUI co-editing with `visual_mode=shared-desktop`. | Already-open ordinary Desktop sessions that the user does not want to reconnect as `mphclient`. |
-| Desktop attach / Java Shell | Fallback for small visible Desktop edits, quick plots/tables, and user-in-the-loop adjustments in an already-open ordinary COMSOL window. | Long builders, heavy debugging, or anything that needs reliable structured exceptions or server-side inspect. |
+| sim runtime / JPype | Building, solving, inspecting, debugging, saving `.mph`, repeatable case generation, and reliable live GUI co-editing with `visual_mode=shared-desktop`. | Only avoid when the user explicitly refuses a server-backed/shared Desktop session. |
+| Desktop attach / Java Shell | Rare fallback for explicit small edits in an already-open ordinary COMSOL window when server-backed shared Desktop is not acceptable. | Default agent routing, long builders, heavy debugging, solves, validation, or anything that needs reliable structured exceptions or server-side inspect. |
 | saved `.mph` inspection | Offline summaries, archive diffs, and artifact review without starting COMSOL. | Mutating live model state. |
 
 For the sim runtime, start with `uv run sim check comsol`, then
@@ -40,11 +41,8 @@ uv run sim inspect session.health
 
 Confirm `ui_capabilities.model_builder_live: true`,
 `active_model_tag`, and `live_model_binding.ok: true` before treating the GUI
-as synchronized with agent edits. For Desktop attach fallback, start with
-`sim-comsol-attach open --json --timeout 120` or
-`sim-comsol-attach health --json`, then submit bounded Java Shell snippets with
-`--submit-key ctrl_enter`. The returned `session.versions` payload tells you
-which COMSOL-specific subfolders to load:
+as synchronized with agent edits. The returned `session.versions` payload tells
+you which COMSOL-specific subfolders to load:
 
 ```json
 "session.versions": {
@@ -74,10 +72,11 @@ plugin-owned content focused on the driver protocol, live introspection,
 debug loops, and the smallest smoke/reference workflow.
 
 Each numbered step is a self-contained snippet for the sim runtime after
-`uv run sim connect --solver comsol`. For Desktop attach, translate only small bounded
-steps into Java Shell snippets. Do not assume a Java Shell session always
-provides a prebound `model` or `m` variable; probe with a tiny print first, and
-prefer the sim runtime when you need a reliable model handle.
+`uv run sim connect --solver comsol`. For the rare Desktop attach fallback,
+translate only small bounded steps into Java Shell snippets. Do not assume a
+Java Shell session always provides a prebound `model` or `m` variable; probe
+with a tiny print first, and prefer the sim runtime when you need a reliable
+model handle.
 
 Before running a new or complex workflow, read
 [`base/reference/runtime_introspection.md`](base/reference/runtime_introspection.md)
@@ -239,9 +238,10 @@ Use this policy:
   a clear model tag derived from the case name.
 - If starting from scratch in the sim runtime, pass a descriptive
   `model_tag=<case_slug>` when connecting if the current driver supports it.
-- If starting from scratch in shared Desktop or Desktop attach mode, bind to
-  the active Desktop model first, then set a visible title/label and save it
-  early to an absolute `.mph` path.
+- If starting from scratch in shared Desktop mode, bind to the active Desktop
+  model first, then set a visible title/label and save it early to an absolute
+  `.mph` path. Apply the same identity rule to the rare Desktop attach fallback
+  before making any visible edit.
 - Keep all related files under one working folder, for example:
 
 ```text
@@ -305,16 +305,16 @@ assignment.
    - Use `uv run sim connect --solver comsol --ui-mode gui --driver-option
      visual_mode=shared-desktop` when the user wants real-time Model Builder
      visibility and the agent needs structured `uv run sim inspect`/JPype state.
-   - Use the standalone Desktop attach helper only when the user already
-     opened ordinary COMSOL Desktop, wants to avoid the `mphclient` server
-     login/session switch, or needs a small human-in-the-loop edit.
    - Use plain `uv run sim connect --solver comsol` for no-GUI/server execution,
      driver-managed artifacts, and existing sim runtime workflows.
-2. For Desktop attach, run `sim-comsol-attach open --json --timeout 120` or
-   `sim-comsol-attach health --json`, then confirm the Java Shell channel is
-   ready.
-3. For sim runtime, run `uv run sim check comsol`, connect if needed, and read
+   - Use the standalone Desktop attach helper only when the user explicitly
+     chooses a small edit in an already-open ordinary Desktop and does not want
+     the server-backed `shared-desktop` path.
+2. For sim runtime, run `uv run sim check comsol`, connect if needed, and read
    `session.versions` plus `uv run sim inspect session.health`.
+3. If the user explicitly chose Desktop attach, run `sim-comsol-attach open
+   --json --timeout 120` or `sim-comsol-attach health --json`, then confirm the
+   Java Shell channel is ready before submitting any snippet.
 4. Establish or verify model identity, working folder, and checkpoint target.
    For sim runtime, inspect `comsol.model.identity` when available. For
    Desktop attach, probe the visible model title/file path through Java Shell
@@ -348,7 +348,7 @@ COMSOL has several visual surfaces. Do not collapse them into one
 | `server-graphics` | `comsolmphserver -graphics`; plot windows may appear when a result plot is run. `ui_mode=gui` is an alias for this. | Yes for the server-side model, but there is no Model Builder tree. |
 | `desktop-inspection` | Save a `.mph` artifact, then open it in full COMSOL Desktop / Model Builder. | No. It is an inspection copy unless explicitly reloaded. |
 | `shared-desktop` | Full COMSOL Desktop attached to the same server, with the agent binding to the Desktop's active model tag. Request from sim-cli with `--driver-option visual_mode=shared-desktop`. | Yes, when `model_builder_live: true`. |
-| `desktop-attach` | Fallback ordinary COMSOL Desktop path, controlled through the Java Shell UIA channel via `sim-comsol-attach`. No `mphclient`, no shared server login dialog. | Yes, in the visible Desktop model, but without `uv run sim inspect`/JPype session introspection. |
+| `desktop-attach` | Advanced fallback for an already-open ordinary COMSOL Desktop, controlled through the fragile Java Shell UIA channel via `sim-comsol-attach`. No `mphclient`, no shared server login dialog. | Yes, in the visible Desktop model, but without `uv run sim inspect`/JPype session introspection. |
 
 Use `uv run sim inspect session.health` or `uv run sim exec` target `session.health`
 to check `requested_ui_mode`, `effective_ui_mode`, `ui_capabilities`,
@@ -356,14 +356,16 @@ PIDs, logs, and visible COMSOL window titles. Treat `model_builder_live:
 false` as authoritative: agent-side JPype edits will not automatically
 refresh a separately opened COMSOL Desktop window.
 
-### Ordinary Desktop attach helper
+### Advanced fallback: Ordinary Desktop attach helper
 
-For already-open ordinary Desktop sessions, the standalone helper is the
-fallback path. Agents and humans must use the same command path:
-prefer `uvx --from sim-plugin-comsol sim-comsol-attach ...` over relying
-on a PATH-installed `sim-comsol-attach.exe`. This keeps development,
-documentation, and user reproduction aligned even when Python user
-Scripts directories are not on PATH.
+Skip this section for normal COMSOL work. Use the standalone helper only when
+the user explicitly wants a small edit in an already-open ordinary Desktop
+session and does not want to reconnect through the server-backed
+`shared-desktop` path. Agents and humans must use the same command path: prefer
+`uvx --from sim-plugin-comsol sim-comsol-attach ...` over relying on a
+PATH-installed `sim-comsol-attach.exe`. This keeps development, documentation,
+and user reproduction aligned even when Python user Scripts directories are not
+on PATH.
 
 ```powershell
 uvx --from sim-plugin-comsol sim-comsol-attach open --json --timeout 120
@@ -396,7 +398,9 @@ For `exec`, submit bounded Java Shell snippets that use COMSOL's Java API
 against the visible Desktop model. Keep the same modeling discipline as
 `uv run sim exec`: one layer at a time, verify the Desktop after each geometry,
 material, physics, mesh, solve, and plot step, then continue. The helper
-audits submissions under `.sim/comsol-desktop-attach/audit.jsonl`.
+audits submissions under `.sim/comsol-desktop-attach/audit.jsonl`. Do not use
+this path as evidence that a full solve or long workflow succeeded unless you
+independently verify the resulting COMSOL state or artifacts.
 
 COMSOL 6.4 Desktop gotchas:
 - User-opened model windows may be titled `Untitled.mph - COMSOL


### PR DESCRIPTION
## Summary
- Remove the fragile Java Shell/UIA Desktop attach workflow from the public README's primary COMSOL paths.
- Keep the bundled skill aware of Desktop attach, but mark it as an advanced fallback only for explicit small edits in an already-open ordinary Desktop session.
- Preserve `shared-desktop` as the recommended visible COMSOL workflow.

## Validation
- `git diff --check HEAD~1..HEAD`
- `uv run pytest` could not start locally because this Mac lacks a Java runtime, so `jpype1` failed to build before tests ran.
- `./.venv/bin/python -m pytest` could not run because the existing venv does not have `pytest` installed.