### PR TITLE
[codex] Document COMSOL MPH compact and Java export flows

### DIFF
--- a/src/sim_plugin_comsol/_skills/comsol/base/reference/java_batch_patterns.md
+++ b/src/sim_plugin_comsol/_skills/comsol/base/reference/java_batch_patterns.md
@@ -8,6 +8,52 @@ Prefer it for settled deterministic recipes and reproducible/CI/fan-out runs
 path in `java_api_patterns.md`, which targets a live Python-driven session for
 stateful building and introspection.
 
+## Exporting an existing `.mph` as Java source
+
+Do not rely on `comsolbatch -inputfile model.mph -outputfile model.java` for
+source export. Verified on 2026-05-19 with COMSOL 6.4: that command saved a
+COMSOL `.mph` ZIP container with a `.java` filename, not Java source.
+
+Use the COMSOL API save type instead:
+
+```java
+import com.comsol.model.*;
+import com.comsol.model.util.*;
+
+public class MphToJava {
+  public static Model run() throws Exception {
+    Model model = ModelUtil.load("m", "C:\\path\\input.mph");
+    model.resetHist(); // optional: compact model history before export
+    model.save("C:\\path\\output.java", "java");
+    return model;
+  }
+
+  public static void main(String[] args) throws Exception { run(); }
+}
+```
+
+Then compile and run the wrapper:
+
+```powershell
+& "C:\Program Files\COMSOL\COMSOL64\Multiphysics\bin\win64\comsolcompile.exe" MphToJava.java
+& "C:\Program Files\COMSOL\COMSOL64\Multiphysics\bin\win64\comsolbatch.exe" -inputfile MphToJava.class
+```
+
+If the host has Python `mph`, the shorter batchable form is:
+
+```python
+import mph
+
+client = mph.Client(cores=1)
+model = client.load(r"C:\path\input.mph")
+model.clear()  # optional: clears stored plot, solution, and mesh data
+model.reset()  # optional: resets modeling history
+model.save(r"C:\path\output.java")
+```
+
+The output should be readable Java source starting with imports such as
+`com.comsol.model.*`, not a file with ZIP magic bytes (`PK`).
+
 ## Skeleton
 
 ```java

--- a/src/sim_plugin_comsol/_skills/comsol/base/reference/mph_file_format.md
+++ b/src/sim_plugin_comsol/_skills/comsol/base/reference/mph_file_format.md
@@ -39,6 +39,27 @@ See `runtime_introspection.md` for the live-session workflow.
 - **`solved`** — full mesh + solution blocks. Largest on disk.
 - **`preview`** — Application Library placeholder. Only `modelinfo.xml` + `modelimage.png` present; `index.txt` plus a 0-byte `preview` entry mark it. The full content streams from the gallery on demand.
 
+## Creating a compact copy from the command line
+
+Use COMSOL's batch binary when the user wants to strip a solved `.mph` down
+to reusable model setup without opening Desktop:
+
+```powershell
+& "C:\Program Files\COMSOL\COMSOL64\Multiphysics\bin\win64\comsolbatch.exe" `
+  -inputfile "full.mph" `
+  -outputfile "compact.mph" `
+  -clearsolution -clearmesh -resethistory -norun
+```
+
+- `-clearsolution` removes solution data while preserving studies/solver setup.
+- `-clearmesh` removes built mesh data while preserving the mesh sequence.
+- `-resethistory` compacts model history before saving.
+- `-norun` prevents recomputation; the command only opens, strips, and saves.
+
+Verified on 2026-05-19 with COMSOL 6.4: a local solved HBM/HBN model went
+from 19.83 MiB (`nodeType=solved`, two `savepoint*` entries) to 0.47 MiB
+(`nodeType=compact`, no savepoint entries), about 2.4% of the original size.
+
 ## Global Parameter contract
 
 Global Parameters in `dmodel.xml`:


### PR DESCRIPTION
## Summary

- Document the COMSOL batch command for stripping solved `.mph` files to compact setup-only artifacts.
- Document the safe `.mph` to Java source export path through `model.save(..., "java")`.
- Call out the `comsolbatch -outputfile model.java` pitfall, which saves an MPH container with a `.java` extension rather than source.

## Validation

- Ran `git diff --check` on the docs changes.
- Verified the compact `.mph` flow locally with COMSOL 6.4 on 2026-05-19: 19.83 MiB solved artifact to 0.47 MiB compact artifact.
- Verified the Java export pitfall and API export behavior locally with COMSOL 6.4.