### PR TITLE
[codex] Ignore COMSOL temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ dist/
 .ruff_cache/
 .uv/
 runs/
+
+*.log
+.sim/


### PR DESCRIPTION
## Summary

- Ignore runtime `.sim/` directories produced by local COMSOL/sim runs.
- Ignore `.log` files so temporary server logs do not dirty the worktree.

## Validation

- Confirmed `git status` only included `.gitignore` before commit.
- No code tests run; this is a gitignore-only change.