### PR TITLE
Guide long-running COMSOL execution

### DIFF
--- a/src/sim_plugin_comsol/_skills/comsol/SKILL.md
+++ b/src/sim_plugin_comsol/_skills/comsol/SKILL.md
@@ -283,6 +283,32 @@ output:
 
 ---
 
+## Long-running execution and recovery
+
+Keep bounded COMSOL work in the foreground when it fits the active tool-call
+budget. Move a settled solve to native batch or a background process only when
+it is expected to outlive that budget, must continue across agent turns, or the
+user explicitly asks for background execution. Keep live sessions for
+incremental inspection and mutation; prefer `comsolbatch` for a settled,
+repeatable long solve.
+
+For a long batch run, use absolute `-batchlog` and `-outputfile` paths so the
+agent can inspect progress and results later. Do not require a fixed directory
+tree, a job manifest, or sim-cli when the direct COMSOL command is sufficient.
+
+A shell or tool timeout ends that observation call; it does not prove COMSOL
+stopped. Before retrying or stopping, check the existing process, batch-log
+tail, and output-file timestamps. Confirm process ownership from the
+executable, full command line, start time, and batch-log/output targets. Never
+terminate every `comsol` process by name.
+
+Use *resume* only when a saved `.mph` or another COMSOL-native checkpoint
+contains state that can actually continue the solve. Without a usable
+checkpoint, describe the action as a restart rather than promising generic
+resume behavior.
+
+---
+
 ## Path-scoped guardrails
 
 Use these guardrails in the path where they apply. They are meant to preserve

--- a/tests/test_skill_contract.py
+++ b/tests/test_skill_contract.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILL = (
+    REPO_ROOT
+    / "src"
+    / "sim_plugin_comsol"
+    / "_skills"
+    / "comsol"
+    / "SKILL.md"
+)
+
+
+def test_long_running_guidance_preserves_direct_comsol_paths() -> None:
+    text = SKILL.read_text(encoding="utf-8")
+    flat = " ".join(text.split())
+
+    assert "## Long-running execution and recovery" in text
+    assert "it does not prove COMSOL stopped" in flat
+    assert "full command line, start time" in flat
+    assert "Never terminate every `comsol` process by name" in flat
+    assert "COMSOL-native checkpoint" in flat
+    assert "restart rather than promising generic resume" in flat
+    assert (
+        "Do not require a fixed directory tree, a job manifest, or sim-cli" in flat
+    )
+    assert "Call `comsolbatch.exe` directly" in text
+    assert "always run COMSOL in the background" not in text


### PR DESCRIPTION
## What changed

- add concise long-running execution and recovery guidance to the COMSOL skill
- distinguish tool-call timeout from solver termination
- require process ownership checks before stopping and native checkpoints before calling an action resume
- add a repo-level skill contract test

## Why

Recent real solver sessions show progress and recovery questions, but not enough evidence to justify a durable job subsystem. This keeps direct COMSOL and live-session paths flexible while making safe recovery evidence explicit.

## Validation

- skill-creator quick validation
- `uv run pytest tests/test_skill_contract.py tests/test_wheel_contents.py -q --basetemp .pytest_basetemp/long-run-skill`
- `uv run ruff check tests/test_skill_contract.py`
- `git diff --check`

